### PR TITLE
feat(tests): pin all promptfoo model IDs to dated versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Pinned all promptfoo model IDs from floating `claude-sonnet-4-6` / `sonnet` to dated `claude-sonnet-4-6-20250514` across YAML configs and SDK provider files, preventing silent behavior drift when new model versions are released
+
 ## [3.3.0] - 2026-04-21
 
 ### Fixed

--- a/tests/promptfoo/agents/biblical-scholar/promptfooconfig-red.yaml
+++ b/tests/promptfoo/agents/biblical-scholar/promptfooconfig-red.yaml
@@ -6,7 +6,7 @@
 description: "biblical-scholar — RED phase (bare model, no agent, no MCP)"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:

--- a/tests/promptfoo/agents/data-retriever/promptfooconfig-red.yaml
+++ b/tests/promptfoo/agents/data-retriever/promptfooconfig-red.yaml
@@ -16,7 +16,7 @@
 description: "data-retriever — RED phase (bare model, no agent, no MCP)"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:

--- a/tests/promptfoo/agents/study-evaluator/promptfooconfig-red.yaml
+++ b/tests/promptfoo/agents/study-evaluator/promptfooconfig-red.yaml
@@ -6,7 +6,7 @@
 description: "study-evaluator — RED phase (bare model, no agent, no MCP)"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:

--- a/tests/promptfoo/providers/grader.agent-sdk.yaml
+++ b/tests/promptfoo/providers/grader.agent-sdk.yaml
@@ -4,5 +4,5 @@
 id: anthropic:claude-agent-sdk
 label: grader
 config:
-  model: sonnet
+  model: claude-sonnet-4-6-20250514
   temperature: 0

--- a/tests/promptfoo/providers/grader.yaml
+++ b/tests/promptfoo/providers/grader.yaml
@@ -1,6 +1,6 @@
-# DEPRECATED: Use anthropic:messages:claude-sonnet-4-6 inline in configs.
+# DEPRECATED: Use anthropic:messages:claude-sonnet-4-6-20250514 inline in configs.
 # This file is retained for rollback reference only.
-id: anthropic:messages:claude-sonnet-4-6
+id: anthropic:messages:claude-sonnet-4-6-20250514
 label: grader
 config:
   temperature: 0

--- a/tests/promptfoo/providers/sdk-bare.mjs
+++ b/tests/promptfoo/providers/sdk-bare.mjs
@@ -21,7 +21,7 @@ export default class SdkBareProvider extends SdkProvider {
       ...options,
       id: options.id || "sdk-bare",
       config: {
-        model: "sonnet",
+        model: "claude-sonnet-4-6-20250514",
         working_dir: "/tmp",
         ...options.config,
       },
@@ -30,7 +30,7 @@ export default class SdkBareProvider extends SdkProvider {
 
   buildOptions(_cwd) {
     return {
-      model: this.config.model || "sonnet",
+      model: this.config.model || "claude-sonnet-4-6-20250514",
       tools: [],              // No built-in tools
       mcpServers: {},         // No MCP servers
       plugins: [],            // No plugins

--- a/tests/promptfoo/providers/sdk-grader.mjs
+++ b/tests/promptfoo/providers/sdk-grader.mjs
@@ -17,7 +17,7 @@ export default class SdkGraderProvider extends SdkProvider {
       ...options,
       id: options.id || "sdk-grader",
       config: {
-        model: "sonnet",
+        model: "claude-sonnet-4-6-20250514",
         working_dir: "/tmp",
         ...options.config,
       },
@@ -26,7 +26,7 @@ export default class SdkGraderProvider extends SdkProvider {
 
   buildOptions(_cwd) {
     return {
-      model: this.config.model || "sonnet",
+      model: this.config.model || "claude-sonnet-4-6-20250514",
       tools: [],          // No tools needed for grading
       mcpServers: {},
       plugins: [],

--- a/tests/promptfoo/providers/sdk-with-skill.mjs
+++ b/tests/promptfoo/providers/sdk-with-skill.mjs
@@ -71,7 +71,7 @@ export default class SdkWithSkillProvider extends SdkProvider {
       ...options,
       id: options.id || "sdk-with-skill",
       config: {
-        model: "sonnet",
+        model: "claude-sonnet-4-6-20250514",
         working_dir: REPO_ROOT,
         max_budget_usd: 3.00,
         max_turns: 50,
@@ -82,7 +82,7 @@ export default class SdkWithSkillProvider extends SdkProvider {
 
   buildOptions(cwd) {
     return {
-      model: this.config.model || "sonnet",
+      model: this.config.model || "claude-sonnet-4-6-20250514",
       mcpServers: {
         "claude-of-alexandria-mcp": {
           type: "http",

--- a/tests/promptfoo/providers/with-skill.agent-sdk.yaml
+++ b/tests/promptfoo/providers/with-skill.agent-sdk.yaml
@@ -4,7 +4,7 @@
 id: anthropic:claude-agent-sdk
 label: with-skill
 config:
-  model: sonnet
+  model: claude-sonnet-4-6-20250514
   working_dir: ../../
   # setting_sources: project intentionally omitted — was previously removed
   # because it inherits z.ai WebSearch from .claude/settings.local.json,

--- a/tests/promptfoo/providers/without-skill.agent-sdk.yaml
+++ b/tests/promptfoo/providers/without-skill.agent-sdk.yaml
@@ -7,7 +7,7 @@
 id: anthropic:claude-agent-sdk
 label: without-skill
 config:
-  model: sonnet
+  model: claude-sonnet-4-6-20250514
   working_dir: /tmp
   permission_mode: bypassPermissions
   allow_dangerously_skip_permissions: true

--- a/tests/promptfoo/providers/without-skill.yaml
+++ b/tests/promptfoo/providers/without-skill.yaml
@@ -1,4 +1,4 @@
-# DEPRECATED: Use anthropic:messages:claude-sonnet-4-6 inline in configs.
+# DEPRECATED: Use anthropic:messages:claude-sonnet-4-6-20250514 inline in configs.
 # This file is retained for rollback reference only.
-id: anthropic:messages:claude-sonnet-4-6
+id: anthropic:messages:claude-sonnet-4-6-20250514
 label: without-skill

--- a/tests/promptfoo/skills/argument-flow/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/argument-flow/promptfooconfig-red.yaml
@@ -19,7 +19,7 @@
 description: "Argument Flow — RED phase (bare model, no skill, no MCP)"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:

--- a/tests/promptfoo/skills/biblical-segmentation/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/biblical-segmentation/promptfooconfig-red.yaml
@@ -23,7 +23,7 @@
 description: "Biblical Segmentation — RED phase (bare model, no skill, no MCP)"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:

--- a/tests/promptfoo/skills/consult-biblical-scholar/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/consult-biblical-scholar/promptfooconfig-red.yaml
@@ -15,7 +15,7 @@
 description: "Consult Biblical Scholar — RED phase (bare model, no skill, no MCP)"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
@@ -23,7 +23,7 @@
 description: "Exegetical Notes — RED phase (bare model, no skill, no MCP)"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:

--- a/tests/promptfoo/skills/pericope-delimitation/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/pericope-delimitation/promptfooconfig-red.yaml
@@ -16,7 +16,7 @@
 description: "Pericope Delimitation — RED phase (bare model, no skill, no MCP)"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:

--- a/tests/promptfoo/smoke/promptfooconfig-cli-provider.yaml
+++ b/tests/promptfoo/smoke/promptfooconfig-cli-provider.yaml
@@ -6,7 +6,7 @@
 description: "Smoke test — sdk-bare provider isolation"
 
 providers:
-  - id: anthropic:messages:claude-sonnet-4-6
+  - id: anthropic:messages:claude-sonnet-4-6-20250514
     label: bare-model
 
 prompts:
@@ -15,7 +15,7 @@ prompts:
 defaultTest:
   options:
     provider:
-      id: anthropic:messages:claude-sonnet-4-6
+      id: anthropic:messages:claude-sonnet-4-6-20250514
       config:
         temperature: 0
 


### PR DESCRIPTION
## Summary
- Replaces all floating model references (`claude-sonnet-4-6`, `sonnet`) with dated `claude-sonnet-4-6-20250514` across 17 files
- Covers YAML promptfoo configs (RED phase, smoke, providers) and SDK provider `.mjs` files
- Adds CHANGELOG entry under [Unreleased]

Closes #15

## Test plan
- [ ] Smoke regression run passes with pinned model IDs
- [ ] No floating model references remain in `tests/promptfoo/`