### PR TITLE
feat(tests): add apocalyptic-genre RED/GREEN scenarios for Rev 1:9-20

### DIFF
--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-green.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-green.yaml
@@ -6,6 +6,7 @@
 # GREEN phase — skill correction verification:
 #   S1-S7: Core scenarios (structure, data-grounding, tiers, pericope, OT, verification, scholarly)
 #   S8-S12: Phase 4 scenarios (cross-ref labeling, entity data, speaker data, gloss tiers, variants)
+#   S14: Apocalyptic genre governance (Rev 1:9-20)
 
 description: "Exegetical Notes — GREEN phase (failure-mode corrections)"
 
@@ -365,3 +366,56 @@ tests:
           diverge, not the manuscript evidence for each reading.
           FAIL if edition comparison data is presented as manuscript-level evidence
           (e.g., claiming to show papyrus/uncial support for readings).
+
+  # =========================================================================
+  # Scenario 14: Apocalyptic Genre Governance — Rev 1:9-20
+  # Core failure: apocalyptic imagery allegorized without genre-specific method,
+  # OT prophetic backgrounds missing, redemptive-historical arc untraced
+  # =========================================================================
+  - description: "S14 GREEN: Apocalyptic genre — Rev 1:9-20 with genre governance"
+    vars:
+      prompt: "Generate exegetical notes for Revelation 1:9-20 --output print"
+    assert:
+      # --- Genre identification in header ---
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          return {
+            pass: lower.includes('genre:') && lower.includes('apocalyptic'),
+            score: lower.includes('apocalyptic') ? 1 : 0,
+            reason: lower.includes('apocalyptic')
+              ? 'Genre identified as apocalyptic'
+              : 'Genre not identified as apocalyptic'
+          };
+      # --- OT prophetic background for imagery ---
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          const otRefs = ['daniel 7', 'dan 7', 'zechariah 4', 'zech 4', 'daniel 10', 'dan 10', 'isaiah 49', 'isa 49'];
+          const found = otRefs.filter(r => lower.includes(r));
+          return {
+            pass: found.length >= 2,
+            score: found.length / 3,
+            reason: found.length >= 2
+              ? `OT prophetic backgrounds cited: [${found}]`
+              : `Insufficient OT prophetic backgrounds. Found: [${found}]. Expected at least 2 from: [${otRefs}]`
+          };
+      # --- Genre governance: apocalyptic method constrains interpretation ---
+      - type: llm-rubric
+        value: |
+          Evaluate whether the output applies genre governance to Revelation 1:9-20.
+          PASS if ALL of these are true:
+          - Apocalyptic is explicitly identified as the governing genre
+          - The analysis explains how apocalyptic genre constrains interpretation
+            of the symbolic imagery (lampstands, sword, son-of-man figure)
+          - Symbols are grounded in OT prophetic imagery (e.g., lampstands in
+            Zechariah 4, son of man in Daniel 7, sword in Isaiah 49:2) rather
+            than treated as simple allegory or decoded without literary precedent
+          - The redemptive-historical arc traces the exalted Christ as fulfillment
+            of the Daniel 7 "son of man" prophecy or the broader prophetic tradition
+          - The passage is treated as a visionary report with its own literary
+            conventions, not as narrative or epistolary instruction
+
+          FAIL if symbols are allegorized without OT prophetic grounding, or if
+          apocalyptic genre is not identified as governing the interpretive method,
+          or if the redemptive-historical connection to the prophetic tradition is absent.

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
@@ -19,6 +19,7 @@
 # Phase 6 — OpenGNT / OpenText.org / Variants integration:
 #   S12: Textual variants ignored — variant-rich passage analyzed without edition comparison
 #   S13: NT gloss tiering absent — OpenGNT glosses treated uniformly without tier distinction
+#   S14: Apocalyptic genre mishandled — Rev 1:9-20 treated without genre governance
 
 description: "Exegetical Notes — RED phase (bare model, no skill, no MCP)"
 
@@ -330,3 +331,39 @@ tests:
 
           FAIL if the response explicitly distinguishes between inline and
           concordance glosses, or notes gloss divergence as semantically significant.
+
+  # =========================================================================
+  # Scenario 14: Apocalyptic Genre Governance — Rev 1:9-20
+  # Failure: Apocalyptic imagery allegorized without genre-specific method
+  # Bare model treats apocalyptic like narrative or epistle, misses genre
+  # governance, and allegorizes symbolic imagery without literary-genre context
+  # =========================================================================
+  - description: "S14 RED: Apocalyptic genre — Rev 1:9-20 without genre governance"
+    vars:
+      prompt: "Analyze Revelation 1:9-20 exegetically. Explain the significance of the seven lampstands, the sharp two-edged sword, and the 'one like a son of man' figure. Include the redemptive-historical significance."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response exhibits ANY of these apocalyptic genre failures:
+          - Allegorizes the lampstands, sword, or son-of-man figure without first
+            establishing that Revelation is apocalyptic literature requiring a
+            genre-specific interpretive method (e.g., symbol-referent mapping,
+            OT prophetic background, visionary report conventions)
+          - Treats the passage as straightforward narrative (what happened next)
+            or as epistolary instruction (what to do) rather than as an apocalyptic
+            vision report with its own literary conventions
+          - Does not identify "apocalyptic" as the governing genre or does not
+            explain how apocalyptic genre constrains interpretation
+          - Interprets symbols (lampstands = churches, sword = word of God) as
+            simple allegory without grounding in OT prophetic imagery
+            (e.g., Zechariah 4, Daniel 7, Isaiah 49:2)
+          - Misses the redemptive-historical arc specific to apocalyptic: the
+            exalted Christ revealed in glory as the culmination of Daniel's
+            "son of man" prophecy and the prophetic tradition
+
+          FAIL if the response explicitly identifies apocalyptic as the governing
+          genre, explains how genre constrains interpretation of symbols, grounds
+          imagery in OT prophetic backgrounds (Daniel 7, Zechariah 4), AND traces
+          the redemptive-historical significance through the prophetic tradition.


### PR DESCRIPTION
## Summary
- Adds S14 RED scenario: bare model allegorizes Rev 1:9-20 imagery without genre governance
- Adds S14 GREEN scenario: skill applies apocalyptic genre method with OT prophetic grounding
- GREEN assertions: genre header check (javascript), OT background citations (javascript), genre governance rubric (llm-rubric)

Closes #17

## Test plan
- [ ] RED eval: bare model fails on apocalyptic genre governance as expected
- [ ] GREEN eval: skill corrects with genre identification, OT backgrounds, redemptive-historical arc