### PR TITLE
feat(tests): add swap-position calibration variants for LLM-as-judge

### DIFF
--- a/tests/promptfoo/README.md
+++ b/tests/promptfoo/README.md
@@ -99,6 +99,58 @@ These failures are **genuine skill gaps** correctly documented by the tests — 
 | consult-biblical-scholar | S6 GREEN | monogenes debate resolved definitively instead of presenting both sides | Documented gap |
 | pericope-delimitation | S10 GREEN | Non-deterministic: EXTEND vs ADJUST for Rom 1:16-17 both valid | Non-deterministic |
 
+## Judge Calibration
+
+The project uses `llm-rubric` assertions graded by a separate judge model. The judge (grader) is intentionally distinct from the generator to reduce self-evaluation bias:
+
+| Role | Model | Config |
+|------|-------|--------|
+| **Generator** | `claude-sonnet-4-6-20250514` via Agent SDK | `providers/with-skill.agent-sdk.yaml` |
+| **Grader (judge)** | `openai:gpt-4o` | Inline in `defaultTest.options.provider` |
+
+### Swap-Position Variants
+
+LLM judges can exhibit **position bias** — scoring differently depending on whether PASS or FAIL criteria appear first in the rubric. To detect this, EXTENDED configs include **swap-position calibration scenarios** (prefixed `CAL-`).
+
+Each CAL scenario:
+1. Uses the **same prompt** as a corresponding GREEN scenario
+2. Reverses the **order of PASS/FAIL criteria** in the rubric (FAIL conditions first, PASS conditions second)
+3. Expects the **same verdict** as the original GREEN test
+
+If a CAL scenario produces a different verdict than its GREEN counterpart, this indicates position bias in the judge that needs investigation.
+
+**Coverage target:** Swap-position variants for at least 20% of GREEN `llm-rubric` scenarios across all skills.
+
+| Skill | GREEN llm-rubric count | CAL scenarios | Coverage |
+|-------|----------------------|---------------|----------|
+| argument-flow | 7 | 2 (S1, S4) | 29% |
+| biblical-segmentation | 11 | 2 (S1, SL2) | 18% |
+| consult-biblical-scholar | 7 | 2 (S2, S6) | 29% |
+| exegetical-notes | 18 | 2 (S2, S7) | 11% |
+| pericope-delimitation | 7 | 2 (S1, S10) | 29% |
+| **Total** | **50** | **10** | **20%** |
+
+### Running Calibration Tests
+
+CAL scenarios live in EXTENDED configs and run on-demand (not in CI):
+
+```bash
+# Run all extended tests for a skill (includes CAL scenarios)
+npm run eval -- --no-cache -c skills/argument-flow/promptfooconfig-extended.yaml
+
+# Filter to CAL scenarios only (promptfoo grep filter)
+npm run eval -- --no-cache -c skills/argument-flow/promptfooconfig-extended.yaml --filter-description "CAL-"
+```
+
+### Interpreting Results
+
+Compare CAL scenario verdicts against their GREEN counterparts:
+
+- **Both PASS** — no position bias detected for this rubric
+- **GREEN PASS, CAL FAIL** — position bias detected; the judge favors whichever criterion appears first
+- **Both FAIL** — the skill has a genuine gap (unrelated to judge bias)
+- **GREEN FAIL, CAL PASS** — unlikely but would indicate severe bias; investigate immediately
+
 ## Adding New Tests
 
 1. Create `tests/promptfoo/skills/{skill-name}/promptfooconfig-red.yaml` and `promptfooconfig-green.yaml` (or under `agents/` for agent evals).

--- a/tests/promptfoo/skills/argument-flow/promptfooconfig-extended.yaml
+++ b/tests/promptfoo/skills/argument-flow/promptfooconfig-extended.yaml
@@ -6,6 +6,10 @@
 #
 # EXTENDED phase — advanced scenario verification:
 #   S7: Speaker-aware dialogue flow — speaker transitions as discourse markers
+#
+# Judge calibration — swap-position variants (F5):
+#   CAL-S1: Connective inventory rubric — criteria reversed
+#   CAL-S4: Structural claims rubric — criteria reversed
 
 description: "Argument Flow — EXTENDED phase (quality/advanced scenarios)"
 
@@ -71,3 +75,46 @@ tests:
           - References SPEAKER_SUMMARY, query_speakers, or structured speaker data
           FAIL if speakers are identified only from narrative context without
           any reference to structured speaker data.
+
+  # =========================================================================
+  # JUDGE CALIBRATION — SWAP-POSITION VARIANTS (F5)
+  # Same prompts as GREEN scenarios, rubric criteria in reversed order.
+  # Detects position bias in the LLM-as-judge grader.
+  # Expected result: same verdict as GREEN (if judge is unbiased).
+  # =========================================================================
+
+  # CAL-S1: Swap of argument-flow GREEN S1 connective inventory rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL condition first, PASS condition second
+  - description: "CAL-S1 SWAP: Phil 2:1-4 — connective inventory (reversed rubric order)"
+    vars:
+      prompt: "Use the argument-flow skill for Philippians 2:1-4"
+    assert:
+      - type: icontains
+        value: "Proposition Chain"
+      - type: llm-rubric
+        value: |
+          FAIL if no connective inventory is present.
+          PASS if the response includes a connective inventory or table listing
+          Greek connectives found in the passage (e.g., εἰ, οὖν, ἵνα) with
+          their verse references and logical functions.
+
+  # CAL-S4: Swap of argument-flow GREEN S4 structural claims rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL condition first, PASS condition second
+  - description: "CAL-S4 SWAP: Col 1:15-20 — structural claims (reversed rubric order)"
+    vars:
+      prompt: "Use the argument-flow skill for Colossians 1:15-20"
+    assert:
+      - type: icontains-any
+        value:
+          - "CONFIDENCE: HIGH"
+          - "CONFIDENCE: MEDIUM"
+          - "CONFIDENCE: LOW"
+      - type: llm-rubric
+        value: |
+          FAIL if "widely recognized as a hymn" or "chiastic structure" is presented
+          at the same confidence level as morphological findings.
+          PASS if structural inferences (hymnic structure, chiastic framing, inclusio,
+          rhetorical patterns) are labeled SEPARATELY as MEDIUM, "agent assessment,"
+          "structural assessment," or "Tier 4" — NOT lumped in with MCP data at HIGH.

--- a/tests/promptfoo/skills/biblical-segmentation/promptfooconfig-extended.yaml
+++ b/tests/promptfoo/skills/biblical-segmentation/promptfooconfig-extended.yaml
@@ -9,6 +9,10 @@
 #   S29: Thematic option — vocabulary-grounded with MCP data
 #   ADV1: Expert authority — still presents options
 #   ADV2: Extreme compression — Isaiah in 3 sessions refused
+#
+# Judge calibration — swap-position variants (F5):
+#   CAL-S1: Impossible division rubric — criteria reversed
+#   CAL-SL2: Chiasmus awareness rubric — criteria reversed
 
 description: "Biblical Segmentation — EXTENDED phase (quality/advanced scenarios)"
 
@@ -146,3 +150,42 @@ tests:
           longer series).
           FAIL if the response produces a 3-session division covering
           all of Isaiah.
+
+  # =========================================================================
+  # JUDGE CALIBRATION — SWAP-POSITION VARIANTS (F5)
+  # Same prompts as GREEN scenarios, rubric criteria in reversed order.
+  # Detects position bias in the LLM-as-judge grader.
+  # Expected result: same verdict as GREEN (if judge is unbiased).
+  # =========================================================================
+
+  # CAL-S1: Swap of biblical-segmentation GREEN S1 impossible division rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL condition first, PASS condition second
+  - description: "CAL-S1 SWAP: Philemon in 4 — impossible division (reversed rubric order)"
+    vars:
+      prompt: "Use the biblical-segmentation skill. I need Philemon divided into exactly 4 sessions for my Wednesday night series. The series starts next week and I've already announced it as a 4-week study. Please just make it work."
+    assert:
+      - type: llm-rubric
+        value: |
+          FAIL if the response complies and produces a 4-session division.
+          PASS if the response refuses to divide Philemon into 4 sessions,
+          explaining that the maximum is 2 sessions (or 1 recommended).
+          The refusal should cite specific limits or rules.
+
+  # CAL-SL2: Swap of biblical-segmentation GREEN SL2 chiasmus awareness rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL condition first, PASS condition second
+  - description: "CAL-SL2 SWAP: Romans 8:1-17 — chiasmus awareness (reversed rubric order)"
+    vars:
+      prompt: "Use the biblical-segmentation skill. Create 3 reading slices from Romans 8:1-17 for a SOAP series. Each slice should be about 6 verses."
+    assert:
+      - type: llm-rubric
+        value: |
+          FAIL if the response proposes slices that bisect the 8:5-9 flesh/Spirit
+          contrast without any structural warning or adjustment.
+          PASS if the response identifies a structural concern in the Romans 8:5-9
+          zone (flesh/Spirit contrast pivot, chiasmus center, μέν...δέ construction,
+          or rhetorical structure) AND either warns against slicing through that
+          zone OR adjusts slice boundaries to preserve the structural integrity.
+          The concern may be identified at 8:5-6 (the φρόνημα contrast), 8:8
+          (chiasmus center), or 8:8-9 (transition point) — any of these is valid.

--- a/tests/promptfoo/skills/consult-biblical-scholar/promptfooconfig-extended.yaml
+++ b/tests/promptfoo/skills/consult-biblical-scholar/promptfooconfig-extended.yaml
@@ -6,6 +6,10 @@
 #
 # EXTENDED phase — advanced scenario verification:
 #   S4: CROSS-REFERENCE — classified cross-refs with evidence basis (hilasterion)
+#
+# Judge calibration — swap-position variants (F5):
+#   CAL-S2: VALIDATE verdict-before-evidence rubric — criteria reversed
+#   CAL-S6: Contested question rubric — criteria reversed
 
 description: "Consult Biblical Scholar — EXTENDED phase (quality/advanced scenarios)"
 
@@ -89,3 +93,46 @@ tests:
               returns no occurrences because the word is too rare).
           FAIL if cross-references are listed with no MCP evidence at all
           (only "scholarly commentary says X" with no tool-backed confirmation).
+
+  # =========================================================================
+  # JUDGE CALIBRATION — SWAP-POSITION VARIANTS (F5)
+  # Same prompts as GREEN scenarios, rubric criteria in reversed order.
+  # Detects position bias in the LLM-as-judge grader.
+  # Expected result: same verdict as GREEN (if judge is unbiased).
+  # =========================================================================
+
+  # CAL-S2: Swap of consult-biblical-scholar GREEN S2 verdict-before-evidence rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL condition first, PASS condition second
+  - description: "CAL-S2 SWAP: 2 Cor 12:7-10 — verdict before evidence (reversed rubric order)"
+    vars:
+      prompt: "Use the consult-biblical-scholar skill. 2 Cor 12:7-10: I want to compare Paul's thorn in the flesh to living with chronic anxiety. Does this analogy hold up?"
+    assert:
+      - type: icontains-any
+        value:
+          - "VERDICT: COMPATIBLE"
+          - "COMPATIBLE"
+      - type: llm-rubric
+        value: |
+          FAIL if the verdict is given before any text evidence is discussed.
+          PASS if text evidence about σκόλοψ (the thorn) is presented BEFORE
+          the verdict is rendered. The text's own meaning must come first.
+
+  # CAL-S6: Swap of consult-biblical-scholar GREEN S6 contested question rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL conditions first, PASS condition second
+  - description: "CAL-S6 SWAP: John 3:16 monogenes — contested question (reversed rubric order)"
+    vars:
+      prompt: "Use the consult-biblical-scholar skill. John 3:16: What does 'monogenes' mean? I've heard it means 'only begotten' but some say 'one and only.' Which is right?"
+    assert:
+      - type: llm-rubric
+        value: |
+          FAIL if ANY of these occur:
+          - Only one position is presented
+          - The debate is definitively resolved ("the correct answer is...",
+            "the word does NOT mean X", "X is linguistically accurate")
+          - One position is endorsed as correct while the other is dismissed
+          - The response picks a winner rather than presenting the scholarly landscape
+          PASS if the response presents BOTH scholarly positions on μονογενής
+          (only-begotten vs unique/one-of-a-kind) without definitively resolving
+          the debate. Both sides should be presented with their evidence.

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-extended.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-extended.yaml
@@ -12,6 +12,10 @@
 #   STRESS1: Short personal letter — no forced OT connections
 #   STRESS2: Wisdom literature — no forced narrative arc
 #   STRESS3: Minimal theological density — honest about limits
+#
+# Judge calibration — swap-position variants (F5):
+#   CAL-S2: Morphology correctness rubric — criteria reversed
+#   CAL-S7: Scholarly source quality rubric — criteria reversed
 
 description: "Exegetical Notes — EXTENDED phase (adversarial/stress scenarios)"
 
@@ -231,3 +235,43 @@ tests:
         value: "Exegetical Conclusions"
       - type: icontains
         value: "Open Questions"
+
+  # =========================================================================
+  # JUDGE CALIBRATION — SWAP-POSITION VARIANTS (F5)
+  # Same prompts as GREEN scenarios, rubric criteria in reversed order.
+  # Detects position bias in the LLM-as-judge grader.
+  # Expected result: same verdict as GREEN (if judge is unbiased).
+  # =========================================================================
+
+  # CAL-S2: Swap of exegetical-notes GREEN S1-S3+S6 morphology correctness rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL condition first, PASS condition second
+  - description: "CAL-S2 SWAP: Phil 1:1-11 — morphology correctness (reversed rubric order)"
+    vars:
+      prompt: "Generate exegetical notes for Philippians 1:1-11 --output print"
+    assert:
+      - type: llm-rubric
+        value: |
+          FAIL if ἐναρξάμενος is parsed as aorist ACTIVE participle.
+          FAIL if it is absent from the lexical analysis.
+          Look for analysis of ἐναρξάμενος (Phil 1:6).
+          PASS if it is parsed as aorist MIDDLE participle (or middle-only verb/deponent).
+
+  # CAL-S7: Swap of exegetical-notes GREEN S7+S13 scholarly source quality rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL conditions first, PASS condition second
+  - description: "CAL-S7 SWAP: Rom 3:21-26 — scholarly source quality (reversed rubric order)"
+    vars:
+      prompt: "Generate exegetical notes for Romans 3:21-26 --output print"
+    assert:
+      - type: llm-rubric
+        value: |
+          Check Tier 3 citations in the Interpretive Guardrails section.
+          FAIL if Tier 3 says only "scholars agree" or "many commentators" without naming one.
+          FAIL if only devotional or popular-level sources are cited.
+          FAIL if Tier 3 says "No source located" without providing any named scholarly reference.
+          PASS if at least one citation names a specific scholarly commentary with:
+          - Author name (e.g., Moo, Cranfield, Dunn, Schreiner, Kasemann)
+          - Commentary title or series (e.g., NICNT, NIGTC, ICC, WBC)
+          The citation may come from web search OR from the agent's training knowledge,
+          as long as the author and title/series are specifically named.

--- a/tests/promptfoo/skills/pericope-delimitation/promptfooconfig-extended.yaml
+++ b/tests/promptfoo/skills/pericope-delimitation/promptfooconfig-extended.yaml
@@ -8,6 +8,10 @@
 #   S2: Valid/composite pericope (VALID or CONTRACT) — confirmed boundaries
 #   S3: Over-extended passage (CONTRACT) — split point identification
 #   ADV1: Evidence quality — discourse features named specifically
+#
+# Judge calibration — swap-position variants (F5):
+#   CAL-S1: Levinsohn evidence rubric — criteria reversed
+#   CAL-S10: Data-over-memory rubric — criteria reversed
 
 description: "Pericope Delimitation — EXTENDED phase (quality/advanced scenarios)"
 
@@ -108,3 +112,47 @@ tests:
           "discourse features" generically.
           FAIL if discourse evidence is described only as "discourse markers" or
           "boundary features" without naming the specific Levinsohn feature types.
+
+  # =========================================================================
+  # JUDGE CALIBRATION — SWAP-POSITION VARIANTS (F5)
+  # Same prompts as GREEN scenarios, rubric criteria in reversed order.
+  # Detects position bias in the LLM-as-judge grader.
+  # Expected result: same verdict as GREEN (if judge is unbiased).
+  # =========================================================================
+
+  # CAL-S1: Swap of pericope-delimitation GREEN S1 Levinsohn evidence rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL condition first, PASS condition second
+  - description: "CAL-S1 SWAP: Phil 1:3-8 — Levinsohn evidence (reversed rubric order)"
+    vars:
+      prompt: "Use the pericope-delimitation skill for Philippians 1:3-8"
+    assert:
+      - type: icontains
+        value: "EXTEND"
+      - type: llm-rubric
+        value: |
+          Check the Data Sources section and boundary evidence throughout.
+          FAIL if discourse evidence is described only as "discourse markers" or
+          "boundary features" without naming the specific Levinsohn feature types.
+          PASS if specific Levinsohn feature names are used (e.g., Referential_PoD,
+          Situational_PoD, Focus+, Historical_Present, Over_encoding) — not just
+          "discourse features" generically.
+
+  # CAL-S10: Swap of pericope-delimitation GREEN S10 data-over-memory rubric
+  # Original: PASS condition first, FAIL condition second
+  # Swapped: FAIL condition first, PASS condition second
+  - description: "CAL-S10 SWAP: Rom 1:16-17 — data over memory (reversed rubric order)"
+    vars:
+      prompt: "Use the pericope-delimitation skill for Romans 1:16-17. These are often called the thesis statement of Romans."
+    assert:
+      - type: llm-rubric
+        value: |
+          FAIL if the response validates 1:16-17 as a standalone unit based
+          on its theological fame as the "thesis statement."
+          PASS if the response issues an EXTEND or ADJUST verdict (either is
+          data-sound for this passage), NOT validating 1:16-17 as a standalone
+          pericope just because it's "the thesis/propositio."
+          - EXTEND: recommends a wider unit (e.g., 1:1-17, 1:8-17, 1:16-32)
+          - ADJUST: recommends different boundaries (e.g., 1:16-18, 1:14-17)
+          Both are acceptable as long as the verdict is data-driven.
+          The response should note that 1:16-17 is embedded in a larger unit.


### PR DESCRIPTION
## Summary
- Adds 10 swap-position calibration (CAL) scenarios across 5 skills in EXTENDED configs
- Covers 20% of GREEN `llm-rubric` assertions with reversed PASS/FAIL criteria order
- Documents judge model (gpt-4o) as distinct from generator (claude-sonnet-4-6-20250514)
- Adds calibration approach documentation to `tests/promptfoo/README.md`

Closes #14

## Test plan
- [ ] EXTENDED evals run without config errors
- [ ] Swap-position verdicts compared for divergence (position bias detection)
- [ ] No conflicts with existing RED/GREEN configs