### PR TITLE
feat(skills): add citation grounding via commentary_lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Citation grounding step (Step 4.5) in `exegetical-notes` skill — Tier A/B scholarly citations are verified against `commentary_lookup` before delivery; unverifiable citations downgraded to "[training knowledge — verify before publication]" caveat
+
 ### Changed
 
 - Pinned all promptfoo model IDs from floating `claude-sonnet-4-6` / `sonnet` to dated `claude-sonnet-4-6-20250514` across YAML configs and SDK provider files, preventing silent behavior drift when new model versions are released

--- a/plugins/claude-of-alexandria/skills/exegetical-notes/SKILL.md
+++ b/plugins/claude-of-alexandria/skills/exegetical-notes/SKILL.md
@@ -2,8 +2,8 @@
 name: exegetical-notes
 description: Use when producing structured exegetical analysis of a biblical passage. Use when user asks for exegetical notes, verse analysis, passage study, word study with morphology, or detailed interpretive framework for a text. Always English output.
 allowed-tools: Agent, Read, Write, WebSearch, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_discourse_features, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_paragraph_breaks, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_vocabulary, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_morphology, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_ot_quotes, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_lemmas, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_themes_for_lemmas, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_theme, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_lexicon, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__check_versification, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_cross_references, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_people, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_places, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_events, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_speakers, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_syntax, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__query_variants, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__bible_lookup, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__commentary_lookup, mcp__plugin_claude-of-alexandria_claude-of-alexandria-mcp__parallel_text
-version: 1.0.0
-changed: "2026-04-30"
+version: 1.1.0
+changed: "2026-05-04"
 ---
 
 # Exegetical Notes
@@ -249,6 +249,33 @@ Step 3: PERICOPE CHECK (MANDATORY — DO NOT SKIP)
 Step 4: Web search for Tier 3 scholarly sources
    → Prefer Tier A/B (NICNT, NIGTC, ICC, WBC, BECNT, Hermeneia, BDAG)
    → Note author, title, publisher
+
+Step 4.5: CITATION GROUNDING via commentary_lookup (MANDATORY for Tier A/B citations)
+   │
+   │  After drafting Tier 3 citations (Step 4 or during Section 6 composition):
+   │
+   │  For each Tier A/B citation that references a specific author's position:
+   │  1. Call commentary_lookup for the passage to check if the cited commentary
+   │     is available in the bundled dataset (adam-clarke, jamieson-fausset-brown,
+   │     john-gill, keil-delitzsch, matthew-henry, tyndale)
+   │  2. If the cited author IS in the bundled commentaries:
+   │     - Verify the commentary text supports the attributed position
+   │     - If CONFIRMED: retain the citation as-is
+   │     - If CONTRADICTED: flag the discrepancy in the citation:
+   │       "[commentary_lookup contradicts: commentary text says X, not Y — verify]"
+   │     - If NO RESULT for that passage range: retain citation but add caveat:
+   │       "[not verified via commentary_lookup — passage not covered]"
+   │  3. If the cited author is NOT in the bundled commentaries (e.g., modern
+   │     commentaries like Moo, Fee, O'Brien): the citation cannot be grounded
+   │     via this tool. Mark it:
+   │     "[training knowledge — verify before publication]"
+   │
+   │  This step prevents fabricated scholarly attributions from reaching the
+   │  final output. A citation that cannot be verified is not removed — it is
+   │  downgraded with an explicit caveat.
+   │
+   │  Available bundled commentaries: adam-clarke, jamieson-fausset-brown,
+   │  john-gill, keil-delitzsch, matthew-henry, tyndale
 
 Step 5: Generate ALL 10 sections using EXACT template titles (Rule 6)
    Every section is mandatory. Never skip, rename, or merge sections.
@@ -558,6 +585,7 @@ Key semantic families from `semantic_groups.yaml` (for Section 4 connections):
 | OpenGNT glosses cited as lexical authority | OpenGNT inline glosses are single-scholar contextual translations. For semantic range arguments, cross-reference with TBESG gloss and query_lexicon. Report divergences as semantic range indicators. |
 | Textual variants ignored for disputed passages | When VARIANTS_SUMMARY shows edition disagreements in the passage, note them in Section 8. Major text-critical issues (Pericope Adulterae, longer ending of Mark, Comma Johanneum) must be flagged. |
 | Clause annotations treated as definitive | SYNTAX_SUMMARY data from OpenText.org is one analytical framework (Porter's SFL). Present as structural evidence, not absolute fact. Data coverage varies by NT book. |
+| Tier A/B citation not grounded via commentary_lookup | After drafting Tier 3 citations, call commentary_lookup for the passage. If the cited author is in the bundled set, verify the position. If not verifiable, mark "[training knowledge — verify before publication]". |
 
 ---
 

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-green.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-green.yaml
@@ -7,6 +7,7 @@
 #   S1-S7: Core scenarios (structure, data-grounding, tiers, pericope, OT, verification, scholarly)
 #   S8-S12: Phase 4 scenarios (cross-ref labeling, entity data, speaker data, gloss tiers, variants)
 #   S14: Apocalyptic genre governance (Rev 1:9-20)
+#   S15: Citation grounding via commentary_lookup (Gal 3:10-14)
 
 description: "Exegetical Notes — GREEN phase (failure-mode corrections)"
 
@@ -419,3 +420,42 @@ tests:
           FAIL if symbols are allegorized without OT prophetic grounding, or if
           apocalyptic genre is not identified as governing the interpretive method,
           or if the redemptive-historical connection to the prophetic tradition is absent.
+
+  # =========================================================================
+  # Scenario 15: Citation Grounding via commentary_lookup — Gal 3:10-14
+  # Core failure: scholarly citations presented without verification against
+  # bundled commentary data; fabricated attributions reach final output
+  # =========================================================================
+  - description: "S15 GREEN: Citation grounding — Tier 3 citations verified via commentary_lookup"
+    vars:
+      prompt: "Generate exegetical notes for Galatians 3:10-14 --output print"
+    assert:
+      # --- commentary_lookup tool was called ---
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          return {
+            pass: lower.includes('commentary_lookup'),
+            score: lower.includes('commentary_lookup') ? 1 : 0,
+            reason: lower.includes('commentary_lookup')
+              ? 'commentary_lookup referenced in output'
+              : 'No mention of commentary_lookup in output'
+          };
+      # --- Citations carry verification caveats ---
+      - type: llm-rubric
+        value: |
+          Check the Interpretive Guardrails section (Section 6) for Tier 3 citations.
+          PASS if:
+          - At least one scholarly citation includes a verification caveat such as
+            "[training knowledge — verify before publication]", "[not verified via
+            commentary_lookup]", or "[commentary_lookup contradicts: ...]"
+          - Modern commentaries not in the bundled set (e.g., Moo, Fee, Longenecker,
+            Bruce) are marked with a training-knowledge caveat rather than presented
+            at full confidence
+          - Citations from bundled commentaries (adam-clarke, jamieson-fausset-brown,
+            john-gill, keil-delitzsch, matthew-henry, tyndale) are either confirmed
+            or flagged if the commentary text does not support the attributed position
+          FAIL if all Tier 3 citations are presented at uniform confidence without
+          any verification caveat or commentary_lookup reference.
+          FAIL if modern scholarly citations (not in the bundled commentary set)
+          are presented without a training-knowledge caveat.

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
@@ -20,6 +20,7 @@
 #   S12: Textual variants ignored — variant-rich passage analyzed without edition comparison
 #   S13: NT gloss tiering absent — OpenGNT glosses treated uniformly without tier distinction
 #   S14: Apocalyptic genre mishandled — Rev 1:9-20 treated without genre governance
+#   S15: Ungrounded citation — Tier A/B citation presented without commentary_lookup verification
 
 description: "Exegetical Notes — RED phase (bare model, no skill, no MCP)"
 
@@ -367,3 +368,33 @@ tests:
           genre, explains how genre constrains interpretation of symbols, grounds
           imagery in OT prophetic backgrounds (Daniel 7, Zechariah 4), AND traces
           the redemptive-historical significance through the prophetic tradition.
+
+  # =========================================================================
+  # Scenario 15: Ungrounded Citation — Fabricated Scholarly Attribution
+  # Failure: Bare model presents plausible-sounding Tier A/B citations without
+  # verifying them against commentary_lookup. Citations may be fabricated or
+  # misattributed (wrong author, wrong position, wrong passage).
+  # =========================================================================
+  - description: "S15 RED: Ungrounded citation — scholarly attribution without commentary verification"
+    vars:
+      prompt: "Analyze Galatians 3:10-14 exegetically. In your interpretive guardrails, cite specific scholarly commentaries on whether 'curse of the law' refers to the Mosaic law's condemnation or a broader principle. Include author, title, and series for each citation."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response cites scholarly commentaries on Galatians 3:10-14
+          without any verification step or caveat indicating the citations were
+          checked against a commentary database. Signs:
+          - Names authors and attributes specific positions to them (e.g., "Longenecker
+            argues...", "Bruce contends...") without noting these are from training
+            knowledge and unverified
+          - Does not mention commentary_lookup or any verification tool
+          - Does not add caveats like "[training knowledge — verify before publication]"
+            or "[not verified via commentary_lookup]"
+          - Presents all scholarly citations at uniform confidence regardless of
+            whether they could be verified against bundled commentary data
+
+          FAIL if the response explicitly marks citations as unverified training
+          knowledge, calls commentary_lookup to verify positions, or adds
+          verification caveats to citations that could not be confirmed.


### PR DESCRIPTION
## Summary
- Inserts Step 4.5 in exegetical-notes: verify Tier A/B citations against `commentary_lookup` before delivery
- Unverifiable citations downgraded to `[training knowledge — verify before publication]`
- Contradictions flagged explicitly rather than silently corrected
- S15 RED/GREEN pair: Galatians 3:10-14 citation verification

Closes #23

## Test plan
- [ ] RED: bare model fabricates/unverified citations for Gal 3:10-14
- [ ] GREEN: skill verifies citations via commentary_lookup with proper caveats