### PR TITLE
feat(skills): add self-critique Step 9 to exegetical-notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adversarial red-team scenarios (prompt injection, multi-turn moralism pressure, theological manipulation persona) in EXTENDED configs for `exegetical-notes` and `pericope-delimitation` skills — tests skill resilience under adversarial user behavior
 - Quarterly run cadence documentation for EXTENDED configs in `tests/promptfoo/README.md`
+- Self-critique Step 9 in `exegetical-notes` skill — 5 binary checks before output delivery: indicative ground for imperative-dominated passages, redemptive-historical link for non-wisdom genres, Tier 3 citation format, verification data quality, and section completeness. Maximum 1 revision iteration if any check fails.
 
 ### Changed
 

--- a/plugins/claude-of-alexandria/skills/exegetical-notes/SKILL.md
+++ b/plugins/claude-of-alexandria/skills/exegetical-notes/SKILL.md
@@ -130,6 +130,19 @@ The output format has exactly 10 sections. Use exactly these section titles:
 
 **Do not abbreviate the output** even if the user asks for "brief" or "essentials." All 10 sections are required for every invocation. The Verification section (Section 10) is never optional.
 
+### Rule 8: Self-Critique Pass Before Delivery
+
+After generating all 10 sections and completing the cross-check (Steps 5-7), run a mandatory self-critique pass (Step 8) with 5 binary checks before delivering output. This is not optional. Do not skip it because the notes "look correct." Do not convince yourself that "this passage doesn't need it."
+
+The 5 checks are:
+1. **Indicative ground** — If Section 2 shows imperative-dominated structure, Section 5 must identify the indicative theological basis for the commands. Imperatives without their warrant is moralism.
+2. **Redemptive-historical link** — For non-wisdom genres, Section 8 must include at least one cross-testament redemptive-historical connection. Missing this flattens the biblical storyline.
+3. **Tier 3 citation format** — Every Tier 3 citation in Section 6 must follow Author (Title, Series, Year) format. A name alone is not a citation.
+4. **Verification data** — Section 10 must contain actual MCP re-query results with specific counts (claims checked, confirmed, corrected), not generic summaries.
+5. **Section completeness** — All 10 sections must be present with exact required titles. No renaming, no omissions.
+
+If any check fails: print a structured correction note, revise the failing section(s), and re-check. Maximum 1 revision iteration. If still failing after revision, deliver with an unresolved note in Section 10.
+
 ### Rule 7: Deliver Output
 
 **File mode** (default, or `--output file`):
@@ -287,7 +300,51 @@ Step 6: Cross-check data claims against MCP tool output
 
 Step 7: Fix any mismatches found in cross-check
 
-Step 8: DELIVER OUTPUT
+Step 8: SELF-CRITIQUE PASS (MANDATORY — DO NOT SKIP)
+   │
+   Run 5 binary checks against the generated notes before delivery:
+   │
+   ├─ Check 1: INDICATIVE GROUND
+   │  Does Section 5 identify the indicative theological ground if
+   │  imperatives dominate the passage (per Section 2 structure)?
+   │  If Section 2 shows imperative-dominated structure and Section 5
+   │  lacks an explicit indicative ground → FAIL
+   │
+   ├─ Check 2: REDEMPTIVE-HISTORICAL LINK
+   │  Does Section 8 include a redemptive-historical connection for
+   │  non-wisdom genres (epistle, narrative, prophecy, apocalyptic)?
+   │  If genre is NOT wisdom/short-letter AND Section 8 lacks a
+   │  redemptive-historical link → FAIL
+   │
+   ├─ Check 3: TIER 3 CITATION FORMAT
+   │  Are all Tier 3 citations in Section 6 in
+   │  Author (Title, Series, Year) format?
+   │  If any Tier 3 citation is a name-drop without title/series → FAIL
+   │
+   ├─ Check 4: VERIFICATION DATA
+   │  Does the Verification section (Section 10) show actual MCP
+   │  re-query results with specific counts, not summaries?
+   │  If Section 10 contains generic text without cross-check counts → FAIL
+   │
+   ├─ Check 5: SECTION COMPLETENESS
+   │  Are all 10 sections present with the exact required titles?
+   │  Are any sections missing or renamed? → FAIL
+   │
+   ├─ ALL CHECKS PASS? → Proceed to Step 9 (deliver)
+   │
+   └─ ANY CHECK FAILS?
+      │
+      ├─ Print structured correction report:
+      │  "[SELF-CRITIQUE] Check N FAILED: [reason]. Correcting..."
+      │
+      ├─ Revise the failing section(s)
+      │
+      ├─ Re-run the 5 checks (max 1 revision iteration)
+      │
+      └─ If still failing after 1 revision: deliver with a
+         "[SELF-CRITIQUE] Unresolved: Check N" note in Section 10
+
+Step 9: DELIVER OUTPUT
    │
    ├─ --output print? → Print ALL 10 sections inline. Do NOT save to file.
    │                     Do NOT summarize. The full document goes in the response.
@@ -586,6 +643,9 @@ Key semantic families from `semantic_groups.yaml` (for Section 4 connections):
 | Textual variants ignored for disputed passages | When VARIANTS_SUMMARY shows edition disagreements in the passage, note them in Section 8. Major text-critical issues (Pericope Adulterae, longer ending of Mark, Comma Johanneum) must be flagged. |
 | Clause annotations treated as definitive | SYNTAX_SUMMARY data from OpenText.org is one analytical framework (Porter's SFL). Present as structural evidence, not absolute fact. Data coverage varies by NT book. |
 | Tier A/B citation not grounded via commentary_lookup | After drafting Tier 3 citations, call commentary_lookup for the passage. If the cited author is in the bundled set, verify the position. If not verifiable, mark "[training knowledge — verify before publication]". |
+| Skipping self-critique pass | Step 8 is mandatory. Run all 5 binary checks before delivery. Do not assume "this passage doesn't need it." |
+| Self-critique finds moralistic Section 5 | If imperatives dominate (per Section 2) and Section 5 lacks indicative ground, the self-critique must catch this and revise before delivery |
+| Self-critique finds missing redemptive-historical link | For non-wisdom genres, Section 8 must have a cross-testament link. Self-critique catches the omission and triggers revision |
 
 ---
 

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-green.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-green.yaml
@@ -8,6 +8,7 @@
 #   S8-S12: Phase 4 scenarios (cross-ref labeling, entity data, speaker data, gloss tiers, variants)
 #   S14: Apocalyptic genre governance (Rev 1:9-20)
 #   S15: Citation grounding via commentary_lookup (Gal 3:10-14)
+#   S16-S17: F4 self-critique (indicative ground, redemptive-historical link)
 
 description: "Exegetical Notes — GREEN phase (failure-mode corrections)"
 
@@ -459,3 +460,90 @@ tests:
           any verification caveat or commentary_lookup reference.
           FAIL if modern scholarly citations (not in the bundled commentary set)
           are presented without a training-knowledge caveat.
+
+  # =========================================================================
+  # Scenario 16: Self-Critique Catches Moralistic Section 5
+  # Core failure: imperatives presented as freestanding moral instruction
+  # without identifying the indicative theological ground
+  # =========================================================================
+  - description: "S16 GREEN: Self-critique — indicative ground for imperative-dominated passage"
+    vars:
+      prompt: "Generate exegetical notes for Colossians 3:1-11 --output print"
+    assert:
+      # --- Indicative ground explicitly identified ---
+      - type: llm-rubric
+        value: |
+          Check Section 5 (Exegetical Conclusions) for Colossians 3:1-11.
+          This passage is dominated by imperatives (seek, set your minds, put to
+          death, put off). The indicative theological ground is the believer's
+          union with Christ: "you have been raised with Christ" (3:1), "you have
+          died" (3:3), "your life is hidden with Christ in God" (3:4).
+
+          PASS if Section 5 explicitly identifies this indicative ground as the
+          theological basis from which the imperatives flow. The analysis must
+          make clear that the commands are warranted by what God has done (the
+          indicative), not presented as freestanding moral instruction.
+
+          FAIL if the imperatives are listed or explained without explicitly
+          identifying the indicative theological ground (union with Christ in
+          death and resurrection) as their warrant.
+      # --- Genre identified as epistle ---
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          return {
+            pass: lower.includes('genre:') && lower.includes('epistle'),
+            score: lower.includes('epistle') ? 1 : 0,
+            reason: lower.includes('epistle')
+              ? 'Genre identified as epistle'
+              : 'Genre not identified as epistle'
+          };
+
+  # =========================================================================
+  # Scenario 17: Self-Critique Ensures Redemptive-Historical Link
+  # Core failure: non-wisdom epistle passage missing cross-testament
+  # redemptive-historical connection in Section 8
+  # =========================================================================
+  - description: "S17 GREEN: Self-critique — redemptive-historical link for epistle"
+    vars:
+      prompt: "Generate exegetical notes for Ephesians 2:1-10 --output print"
+    assert:
+      # --- Redemptive-historical link present in Section 8 ---
+      - type: llm-rubric
+        value: |
+          Check Section 8 (Intertextual Links) for Ephesians 2:1-10.
+          This is an epistle passage (non-wisdom genre), so the skill's
+          self-critique Step 8 requires a redemptive-historical connection
+          placing the passage in the biblical arc.
+
+          PASS if Section 8 includes a redemptive-historical connection that:
+          - Places Eph 2:1-10 in the broader biblical storyline
+            (Creation → Promise → Fulfillment → Consummation)
+          - Traces at least one cross-testament link (e.g., the "dead in
+            trespasses → made alive" pattern connecting to OT themes of
+            exile/restoration, or "by grace through faith" connecting to
+            Abrahamic covenant promise)
+          - Goes beyond flat thematic parallels to show redemptive-historical
+            progression
+
+          FAIL if Section 8 contains only flat cross-references without a
+          redemptive-historical framework, or if no cross-testament link is
+          present connecting Eph 2:1-10 to the broader biblical arc.
+      # --- All 10 sections present ---
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          const sections = [
+            'passage in literary context', 'internal structure',
+            'propositional summary', 'lexical analysis',
+            'exegetical conclusions', 'interpretive guardrails',
+            'open questions', 'intertextual', 'data sources', 'verification'
+          ];
+          const missing = sections.filter(s => !lower.includes(s));
+          return {
+            pass: missing.length === 0,
+            score: 1 - (missing.length / sections.length),
+            reason: missing.length === 0
+              ? 'All 10 sections present'
+              : `Missing: [${missing.join(', ')}]`
+          };

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
@@ -21,6 +21,10 @@
 #   S13: NT gloss tiering absent — OpenGNT glosses treated uniformly without tier distinction
 #   S14: Apocalyptic genre mishandled — Rev 1:9-20 treated without genre governance
 #   S15: Ungrounded citation — Tier A/B citation presented without commentary_lookup verification
+#
+# F4 — Self-critique pass:
+#   S16: Moralistic Section 5 — imperatives without indicative ground (Col 3:1-11)
+#   S17: Missing redemptive-historical link — epistle without cross-testament arc (Eph 2:1-10)
 
 description: "Exegetical Notes — RED phase (bare model, no skill, no MCP)"
 
@@ -332,6 +336,68 @@ tests:
 
           FAIL if the response explicitly distinguishes between inline and
           concordance glosses, or notes gloss divergence as semantically significant.
+
+  # =========================================================================
+  # Scenario 16: Moralistic Section 5 Without Indicative Ground
+  # Failure: Imperative-dominated passage analyzed without identifying the
+  # indicative theological basis for the commands — moralism, not exegesis
+  # =========================================================================
+  - description: "S16 RED: Moralistic Section 5 — imperatives without indicative ground"
+    vars:
+      prompt: "Generate exegetical notes for Colossians 3:1-11. This passage contains many imperatives (seek, set your minds, put to death, put off). Provide a full exegetical analysis with all standard sections."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response presents the imperatives in Colossians 3:1-11 (seek,
+          set your minds, put to death, put off) without explicitly identifying the
+          indicative theological ground that warrants them. Signs:
+          - The imperatives are listed or explained as freestanding moral commands
+            ("Christians should put to death...", "we must set our minds...")
+          - The indicative basis (Col 3:1 "you have been raised with Christ",
+            3:3 "you have died", 3:4 "your life is hidden with Christ") is either
+            absent or mentioned in passing without being identified as THE
+            theological ground for the imperatives
+          - No explicit statement that the commands derive from the believer's
+            union with Christ in his death and resurrection
+          - The analysis reads as moral instruction rather than grounded exegesis
+
+          FAIL if the response explicitly identifies the indicative theological
+          ground (union with Christ in death/resurrection) as the basis from which
+          the imperatives flow, and labels this as the warrant for the commands.
+
+  # =========================================================================
+  # Scenario 17: Missing Redemptive-Historical Link in Section 8
+  # Failure: Non-wisdom passage analyzed without any cross-testament
+  # redemptive-historical connection in the intertextual links
+  # =========================================================================
+  - description: "S17 RED: Missing redemptive-historical link — epistle without cross-testament arc"
+    vars:
+      prompt: "Generate exegetical notes for Ephesians 2:1-10 with full intertextual analysis. Include all cross-references and connections to other biblical passages."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response's intertextual analysis lacks a structured
+          redemptive-historical connection placing Eph 2:1-10 in the biblical
+          arc (Creation → Promise → Fulfillment → Consummation). Signs:
+          - Cross-references are listed as flat parallels without an organizing
+            redemptive-historical framework
+          - No explicit statement tracing Eph 2:1-10's "dead in trespasses" →
+            "made alive with Christ" → "seated in heavenly places" language to
+            the broader biblical storyline of fall and restoration
+          - OT connections (if present) are thematic parallels rather than
+            redemptive-historical links (e.g., "cf. Psalm 103" without noting
+            how Eph 2 fulfills OT promise)
+          - The section organizes cross-references by topic rather than by their
+            place in the redemptive-historical arc
+
+          FAIL if the response includes a structured redemptive-historical
+          connection that explicitly traces the passage's place in the biblical
+          arc from creation through consummation, with OT promise and NT
+          fulfillment clearly linked.
 
   # =========================================================================
   # Scenario 14: Apocalyptic Genre Governance — Rev 1:9-20


### PR DESCRIPTION
## Summary
- Adds Iron Rule 8 (Self-Critique Pass Before Delivery) with 5 binary checks
- Adds Step 8 (self-critique) before delivery step in workflow
- Checks: indicative ground, redemptive-historical link, citation format, verification data, section completeness
- Max 1 revision iteration to bound cost
- S15/S16 RED/GREEN pairs: Col 3:1-11 moralism check, Eph 2:1-10 redemptive-historical link

Closes #18

## Test plan
- [ ] RED: bare model produces moralistic Section 5 (Col 3:1-11) and missing redemptive-historical link (Eph 2:1-10)
- [ ] GREEN: skill's self-critique catches and corrects both failures