### PR TITLE
feat(tests): RED scenario coverage audit — 7 new genre/tool gap pairs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,12 @@ Capture the eval ID from the output line `Eval complete (ID: eval-XXX-...)` and 
 
 ---
 
+## Coverage Matrix
+
+See `docs/coverage-matrix.md` for the RED scenario coverage audit: scenario inventory mapped against biblical books, genres, and MCP tools.
+
+---
+
 ## What Gets Committed
 
 **✅ Commit to Git:**

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -114,3 +114,30 @@ _Cells showing 0 are coverage gaps._
 | query_pericope | — | ✗ NOT COVERED |
 | query_topic | — | ✗ NOT COVERED |
 | query_doctrine | — | ✗ NOT COVERED |
+
+## Gap Analysis — Top 5 Priority Cells
+
+### Gap 1: Poetry/Wisdom — Job (exegetical-notes)
+**Genre:** Poetry/Wisdom | **Book:** Job | **Skills affected:** exegetical-notes, biblical-segmentation
+**Rationale:** Zero wisdom poetry beyond Psalms in RED. Job's theodicy genre requires genre-graduated redemptive-historical method (indirect, not direct arc). Exercises query_speakers (God's speech from whirlwind) and query_theme.
+**Failure mode expected:** Bare model forces narrative arc on wisdom poetry; reads Job as moral instruction without theodicy context.
+
+### Gap 2: Poetry/Wisdom — Ecclesiastes (exegetical-notes, pericope-delimitation)
+**Genre:** Poetry/Wisdom | **Book:** Ecclesiastes | **Skills affected:** exegetical-notes, pericope-delimitation
+**Rationale:** Genre-graduated redemptive-historical approach needed. Bare model likely flattens "meaningless" (hebel) into nihilism or forces premature resolution.
+**Failure mode expected:** Missing genre-graduated method; flat reading without canonical-literary framing.
+
+### Gap 3: Sparse-MCP-data passage — Obadiah (exegetical-notes)
+**Genre:** Prophecy | **Book:** Obadiah | **Skills affected:** exegetical-notes
+**Rationale:** Tests degraded-data fallback when MCP tools (query_places, query_events, query_people) return EMPTY. Exercises query_cross_references for Edom motif.
+**Failure mode expected:** No degraded-data fallback; bare model fills sparse data with training-knowledge hallucinations.
+
+### Gap 4: Law — Leviticus 16 (exegetical-notes)
+**Genre:** Law | **Book:** Leviticus | **Skills affected:** exegetical-notes
+**Rationale:** Zero law genre scenarios. Day of Atonement ritual requires covenantal-fulfillment framework (Heb 9 typology). Exercises query_ot_quotes, query_theme.
+**Failure mode expected:** Flat application of OT ritual law without covenantal fulfillment; either dismissed as irrelevant or applied moralistically.
+
+### Gap 5: OT Apocalyptic — Daniel 7 (argument-flow)
+**Genre:** Apocalyptic | **Book:** Daniel | **Skills affected:** argument-flow
+**Rationale:** Only NT apocalyptic (Rev) tested. OT apocalyptic has different tool coverage (parallel_text, query_ot_quotes). Daniel 7 is the "son of man" source text for NT Christology.
+**Failure mode expected:** Symbolic imagery treated as narrative sequence; no genre governance for OT apocalyptic.

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -1,7 +1,7 @@
 # RED Scenario Coverage Matrix
 
 **Last updated:** 2026-05-04
-**Total RED scenarios:** 51 (skills) + 14 (agents) = 65
+**Total RED scenarios:** 58 (skills) + 14 (agents) = 72 (includes 7 new pairs added by coverage audit)
 
 ## Genre Taxonomy
 
@@ -35,6 +35,10 @@
 | exeg-S15 | exegetical-notes | Gal 3:10-14 | Galatians | Epistle | Ungrounded citation | commentary_lookup |
 | exeg-S16 | exegetical-notes | Col 3:1-11 | Colossians | Epistle | Moralistic without indicative ground | query_morphology |
 | exeg-S17 | exegetical-notes | Eph 2:1-10 | Ephesians | Epistle | Missing redemptive-historical link | query_cross_references |
+| exeg-S18 | exegetical-notes | Job 38:1-11 | Job | Poetry/Wisdom | Forced narrative arc on wisdom | query_morphology, query_vocabulary |
+| exeg-S19 | exegetical-notes | Ecc 1:1-11 | Ecclesiastes | Poetry/Wisdom | Missing genre-graduated method | query_morphology, query_vocabulary |
+| exeg-S20 | exegetical-notes | Obadiah 1-4 | Obadiah | Prophecy | No degraded-data fallback | query_places, query_cross_references |
+| exeg-S21 | exegetical-notes | Lev 16:1-10 | Leviticus | Law | No covenantal-fulfillment framework | query_ot_quotes, query_morphology |
 | arg-S1 | argument-flow | Phil 2:1-4 | Philippians | Epistle | Connective-skipping | query_morphology, query_discourse_features |
 | arg-S3 | argument-flow | Phil 4:4-7 | Philippians | Epistle | Devotional drift | query_morphology, query_discourse_features |
 | arg-S4 | argument-flow | Col 1:15-20 | Colossians | Epistle | Overconfident structural claims | query_morphology, query_discourse_features |
@@ -42,6 +46,7 @@
 | arg-ADV1 | argument-flow | 1 Cor 13:1-3 | 1 Corinthians | Epistle | User pressure compliance | query_morphology, query_discourse_features |
 | arg-S6 | argument-flow | Gen 18:23-29 | Genesis | Narrative | Speaker-unaware dialogue | query_speakers |
 | arg-S8 | argument-flow | Rom 8:28-30 | Romans | Epistle | Clause annotations absent | query_syntax |
+| arg-S9 | argument-flow | Dan 7:9-14 | Daniel | Apocalyptic | Narrative treatment of apocalyptic | query_ot_quotes, query_syntax |
 | seg-S1 | biblical-segmentation | Philemon | Philemon | Epistle | Impossible division compliance | query_paragraph_breaks |
 | seg-S2 | biblical-segmentation | Revelation | Revelation | Apocalyptic | Single contested framework | query_paragraph_breaks |
 | seg-S5 | biblical-segmentation | Psalms 150 | Psalms | Poetry/Wisdom | Mechanical anthology division | query_paragraph_breaks |
@@ -53,11 +58,13 @@
 | seg-SL5 | biblical-segmentation | Gen 24:1-67 | Genesis | Narrative | User-count deference | query_paragraph_breaks |
 | seg-SL6 | biblical-segmentation | Rom 12:1-21 | Romans | Epistle | Method-unaware slicing | query_discourse_features |
 | seg-S23 | biblical-segmentation | Gen 12-25 | Genesis | Narrative | Entity-unaware segmentation | query_people |
+| seg-S24 | biblical-segmentation | Job 1:1-5 | Job | Poetry/Wisdom | Pure narrative segmentation | query_paragraph_breaks |
 | peri-S1 | pericope-delimitation | Eph 4:1-6 | Ephesians | Epistle | Truncated pericope accepted | query_discourse_features |
 | peri-S4 | pericope-delimitation | Gen 37:2-11 | Genesis | Narrative | Narrative-only OT reasoning | query_discourse_features |
 | peri-S7 | pericope-delimitation | Gal 2:20 | Galatians | Epistle | Fame-based leniency | query_discourse_features |
 | peri-S10 | pericope-delimitation | Rom 1:16-17 | Romans | Epistle | Authority-bias validation | query_discourse_features |
 | peri-S11 | pericope-delimitation | Gen 3:14-19 | Genesis | Narrative | Speaker-unaware boundary | query_speakers |
+| peri-S12 | pericope-delimitation | Ecc 3:1-8 | Ecclesiastes | Poetry/Wisdom | Chapter divisions as boundary | query_discourse_features |
 | cbs-S1 | consult-biblical-scholar | Phil 1:1-11 | Philippians | Epistle | Multiple failure modes | query_morphology, query_vocabulary, commentary_lookup |
 | cbs-S2 | consult-biblical-scholar | Phil 1:1-11 | Philippians | Epistle | Lexical accuracy | query_morphology, query_vocabulary |
 | cbs-S3 | consult-biblical-scholar | Phil 1:1-11 | Philippians | Epistle | Confidence tiers absent | query_morphology, query_vocabulary |
@@ -79,14 +86,14 @@
 | Genre | exegetical-notes | argument-flow | biblical-segmentation | pericope-delimitation | consult-biblical-scholar |
 |-------|-----------------|---------------|----------------------|----------------------|-------------------------|
 | Narrative | 3 (Gen) | 1 (Gen) | 7 (Gen, Ps) | 2 (Gen) | 1 (Gen) |
-| Law | 0 | 0 | 0 | 0 | 0 |
-| Poetry/Wisdom | 0 | 0 | 2 (Ps) | 0 | 0 |
-| Prophecy | 0 | 0 | 0 | 0 | 0 |
-| Apocalyptic | 1 (Rev) | 0 | 1 (Rev) | 0 | 0 |
+| Law | 1 (Lev) ★ | 0 | 0 | 0 | 0 |
+| Poetry/Wisdom | 2 (Job, Ecc) ★ | 0 | 3 (Ps, Job) ★ | 1 (Ecc) ★ | 0 |
+| Prophecy | 1 (Obadiah) ★ | 0 | 0 | 0 | 0 |
+| Apocalyptic | 1 (Rev) | 1 (Dan) ★ | 1 (Rev) | 0 | 0 |
 | Epistle | 9 | 6 | 4 | 4 | 8 |
 | Gospel | 1 (John) | 0 | 1 (John) | 0 | 0 |
 
-_Cells showing 0 are coverage gaps._
+_Cells showing 0 are coverage gaps. ★ = added by coverage audit._
 
 ## MCP Tool Coverage
 
@@ -104,7 +111,7 @@ _Cells showing 0 are coverage gaps._
 | query_discourse_features | arg-S1/S3/S4/S5/ADV1, seg-SL2/SL6, peri-S1/S4/S7/S10/S11 | ✓ Covered |
 | query_paragraph_breaks | seg-S1/S2/S22/SL1/SL4/SL5 | ✓ Covered |
 | query_ot_quotes | exeg-S14, bs-S3 | ✓ Covered |
-| query_places | — | ✗ NOT COVERED |
+| query_places | exeg-S20 (Obadiah — degraded-data scenario) ★ | ✓ Covered (degraded-data path) |
 | query_events | — | ✗ NOT COVERED |
 | query_themes | — | ✗ NOT COVERED |
 | query_lexicon | — | ✗ NOT COVERED |

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -1,0 +1,116 @@
+# RED Scenario Coverage Matrix
+
+**Last updated:** 2026-05-04
+**Total RED scenarios:** 51 (skills) + 14 (agents) = 65
+
+## Genre Taxonomy
+
+| Genre | Representative Books | Interpretive Method |
+|-------|---------------------|-------------------|
+| Narrative | Genesis, Exodus (narrative), Joshua–Esther, Jonah, Acts | Scene structure, character analysis, plot arc, discourse markers |
+| Law | Exodus 20–40, Leviticus, Numbers (legal), Deuteronomy | Covenantal context, typological fulfillment, redemptive-historical placement |
+| Poetry/Wisdom | Job, Psalms, Proverbs, Ecclesiastes, Song of Solomon, Lamentations | Parallelism, genre-graduated redemptive-historical (indirect for wisdom), poetic structure |
+| Prophecy | Isaiah, Jeremiah, Ezekiel, Daniel (prose), Minor Prophets | Oracle structure, historical context, fulfillment mapping, covenant lawsuit |
+| Apocalyptic | Daniel 7–12, Revelation | Symbol-referent mapping, OT prophetic backgrounds, visionary report conventions |
+| Epistle | Romans–Jude (excluding Revelation) | Argument flow, discourse connectives, occasion/audience, indicative-imperative structure |
+| Gospel | Matthew, Mark, Luke, John | Narrative + discourse, pericope boundaries, Christological focus, synoptic comparison |
+
+## Scenario Inventory
+
+| ID | Skill | Passage | Book | Genre | Failure Mode | MCP Tools (GREEN) |
+|----|-------|---------|------|-------|-------------|-------------------|
+| exeg-S1 | exegetical-notes | Phil 1:1-11 | Philippians | Epistle | Fabricated verification | query_morphology, query_vocabulary, bible_lookup, commentary_lookup |
+| exeg-S2 | exegetical-notes | Phil 1:1-11 | Philippians | Epistle | Lexical data-grounding errors | query_morphology, query_vocabulary |
+| exeg-S3 | exegetical-notes | Phil 1:1-11 | Philippians | Epistle | Uniform confidence, no tier framework | query_morphology, query_vocabulary |
+| exeg-S4 | exegetical-notes | Phil 1:3-8 | Philippians | Epistle | Uncritical pericope acceptance | bible_lookup |
+| exeg-S5 | exegetical-notes | Gen 37:2-11 | Genesis | Narrative | Unverified Hebrew claims | query_morphology, query_vocabulary |
+| exeg-S7 | exegetical-notes | Rom 3:21-26 | Romans | Epistle | Unverified scholarly attribution | commentary_lookup |
+| exeg-S8 | exegetical-notes | Rom 8:28-30 | Romans | Epistle | Unlabeled cross-references | query_cross_references |
+| exeg-S9 | exegetical-notes | Gen 22:1-4 | Genesis | Narrative | Entity data ignored | query_people |
+| exeg-S10 | exegetical-notes | Gen 3:1-7 | Genesis | Narrative | Speaker data ignored | query_speakers |
+| exeg-S11 | exegetical-notes | Gen 1:1-5 | Genesis | Narrative | Cherith gloss authority | query_vocabulary |
+| exeg-S12 | exegetical-notes | John 7:53-8:11 | John | Gospel | Textual variants ignored | query_variants |
+| exeg-S13 | exegetical-notes | Rom 3:21-26 | Romans | Epistle | NT gloss tiering absent | query_vocabulary |
+| exeg-S14 | exegetical-notes | Rev 1:9-20 | Revelation | Apocalyptic | Apocalyptic genre mishandled | query_ot_quotes |
+| exeg-S15 | exegetical-notes | Gal 3:10-14 | Galatians | Epistle | Ungrounded citation | commentary_lookup |
+| exeg-S16 | exegetical-notes | Col 3:1-11 | Colossians | Epistle | Moralistic without indicative ground | query_morphology |
+| exeg-S17 | exegetical-notes | Eph 2:1-10 | Ephesians | Epistle | Missing redemptive-historical link | query_cross_references |
+| arg-S1 | argument-flow | Phil 2:1-4 | Philippians | Epistle | Connective-skipping | query_morphology, query_discourse_features |
+| arg-S3 | argument-flow | Phil 4:4-7 | Philippians | Epistle | Devotional drift | query_morphology, query_discourse_features |
+| arg-S4 | argument-flow | Col 1:15-20 | Colossians | Epistle | Overconfident structural claims | query_morphology, query_discourse_features |
+| arg-S5 | argument-flow | Eph 2:8-9 | Ephesians | Epistle | Mode confusion | query_morphology, query_discourse_features |
+| arg-ADV1 | argument-flow | 1 Cor 13:1-3 | 1 Corinthians | Epistle | User pressure compliance | query_morphology, query_discourse_features |
+| arg-S6 | argument-flow | Gen 18:23-29 | Genesis | Narrative | Speaker-unaware dialogue | query_speakers |
+| arg-S8 | argument-flow | Rom 8:28-30 | Romans | Epistle | Clause annotations absent | query_syntax |
+| seg-S1 | biblical-segmentation | Philemon | Philemon | Epistle | Impossible division compliance | query_paragraph_breaks |
+| seg-S2 | biblical-segmentation | Revelation | Revelation | Apocalyptic | Single contested framework | query_paragraph_breaks |
+| seg-S5 | biblical-segmentation | Psalms 150 | Psalms | Poetry/Wisdom | Mechanical anthology division | query_paragraph_breaks |
+| seg-S22 | biblical-segmentation | Gen 37-50 | Genesis | Narrative | Masoretic validation missing | query_paragraph_breaks |
+| seg-SL1 | biblical-segmentation | Gen 22:1-13 | Genesis | Narrative | Session framing for slice | query_paragraph_breaks |
+| seg-SL2 | biblical-segmentation | Rom 8:1-17 | Romans | Epistle | Mechanical verse-count division | query_discourse_features |
+| seg-SL3 | biblical-segmentation | John 3:1-21 | John | Gospel | Dialogue-unaware division | query_speakers |
+| seg-SL4 | biblical-segmentation | Psalm 23 | Psalms | Poetry/Wisdom | Short pericope compliance | query_paragraph_breaks |
+| seg-SL5 | biblical-segmentation | Gen 24:1-67 | Genesis | Narrative | User-count deference | query_paragraph_breaks |
+| seg-SL6 | biblical-segmentation | Rom 12:1-21 | Romans | Epistle | Method-unaware slicing | query_discourse_features |
+| seg-S23 | biblical-segmentation | Gen 12-25 | Genesis | Narrative | Entity-unaware segmentation | query_people |
+| peri-S1 | pericope-delimitation | Eph 4:1-6 | Ephesians | Epistle | Truncated pericope accepted | query_discourse_features |
+| peri-S4 | pericope-delimitation | Gen 37:2-11 | Genesis | Narrative | Narrative-only OT reasoning | query_discourse_features |
+| peri-S7 | pericope-delimitation | Gal 2:20 | Galatians | Epistle | Fame-based leniency | query_discourse_features |
+| peri-S10 | pericope-delimitation | Rom 1:16-17 | Romans | Epistle | Authority-bias validation | query_discourse_features |
+| peri-S11 | pericope-delimitation | Gen 3:14-19 | Genesis | Narrative | Speaker-unaware boundary | query_speakers |
+| cbs-S1 | consult-biblical-scholar | Phil 1:1-11 | Philippians | Epistle | Multiple failure modes | query_morphology, query_vocabulary, commentary_lookup |
+| cbs-S2 | consult-biblical-scholar | Phil 1:1-11 | Philippians | Epistle | Lexical accuracy | query_morphology, query_vocabulary |
+| cbs-S3 | consult-biblical-scholar | Phil 1:1-11 | Philippians | Epistle | Confidence tiers absent | query_morphology, query_vocabulary |
+| cbs-S4 | consult-biblical-scholar | Phil 1:3-8 | Philippians | Epistle | Pericope unchecked | query_discourse_features |
+| cbs-S5 | consult-biblical-scholar | Gen 37:2-11 | Genesis | Narrative | OT Hebrew unverified | query_morphology, query_vocabulary |
+| cbs-S6 | consult-biblical-scholar | Rom 3:21-26 | Romans | Epistle | Verification absent | commentary_lookup |
+| cbs-S7 | consult-biblical-scholar | Rom 3:21-26 | Romans | Epistle | Scholarly attribution unverified | commentary_lookup |
+| cbs-S8 | consult-biblical-scholar | Rom 8:28-30 | Romans | Epistle | Cross-reference unlabeled | query_cross_references |
+| bs-S1 | biblical-scholar (agent) | Phil 1:1-11 | Philippians | Epistle | Agent dispatch without skill | query_morphology, query_vocabulary |
+| bs-S2 | biblical-scholar (agent) | Gen 37:2-11 | Genesis | Narrative | OT analysis without skill | query_morphology, query_vocabulary |
+| bs-S3 | biblical-scholar (agent) | Rev 1:9-20 | Revelation | Apocalyptic | Apocalyptic without genre governance | query_ot_quotes |
+| dr-S1 | data-retriever (agent) | Phil 1:1-11 | Philippians | Epistle | Data retrieval without structure | query_morphology, query_vocabulary |
+| dr-S2 | data-retriever (agent) | Gen 37:2-11 | Genesis | Narrative | OT data retrieval | query_morphology, query_vocabulary |
+| se-S1 | study-evaluator (agent) | Phil 1:1-11 | Philippians | Epistle | Evaluation without criteria | query_morphology, query_vocabulary |
+| se-S2 | study-evaluator (agent) | Gen 37:2-11 | Genesis | Narrative | OT evaluation without criteria | query_morphology, query_vocabulary |
+
+## Genre × Skill Heatmap
+
+| Genre | exegetical-notes | argument-flow | biblical-segmentation | pericope-delimitation | consult-biblical-scholar |
+|-------|-----------------|---------------|----------------------|----------------------|-------------------------|
+| Narrative | 3 (Gen) | 1 (Gen) | 7 (Gen, Ps) | 2 (Gen) | 1 (Gen) |
+| Law | 0 | 0 | 0 | 0 | 0 |
+| Poetry/Wisdom | 0 | 0 | 2 (Ps) | 0 | 0 |
+| Prophecy | 0 | 0 | 0 | 0 | 0 |
+| Apocalyptic | 1 (Rev) | 0 | 1 (Rev) | 0 | 0 |
+| Epistle | 9 | 6 | 4 | 4 | 8 |
+| Gospel | 1 (John) | 0 | 1 (John) | 0 | 0 |
+
+_Cells showing 0 are coverage gaps._
+
+## MCP Tool Coverage
+
+| Tool | GREEN Scenarios Using It | Status |
+|------|------------------------|--------|
+| query_morphology | exeg-S1/S2/S3/S5/S7/S16, arg-S1/S3/S4/S5/ADV1/S6, cbs-S1/S2/S3/S5, bs-S1/S2, dr-S1/S2, se-S1/S2 | ✓ Covered |
+| query_vocabulary | exeg-S1/S2/S3/S5/S11/S13, cbs-S1/S2/S3/S5, bs-S1/S2, dr-S1/S2, se-S1/S2 | ✓ Covered |
+| bible_lookup | exeg-S1/S4 | ✓ Covered |
+| commentary_lookup | exeg-S1/S7/S15, cbs-S1/S6/S7 | ✓ Covered |
+| query_cross_references | exeg-S8/S17 | ✓ Covered |
+| query_people | exeg-S9, seg-S23 | ✓ Covered |
+| query_speakers | exeg-S10, arg-S6, peri-S11, seg-SL3 | ✓ Covered |
+| query_variants | exeg-S12 | ✓ Covered |
+| query_syntax | arg-S8 | ✓ Covered |
+| query_discourse_features | arg-S1/S3/S4/S5/ADV1, seg-SL2/SL6, peri-S1/S4/S7/S10/S11 | ✓ Covered |
+| query_paragraph_breaks | seg-S1/S2/S22/SL1/SL4/SL5 | ✓ Covered |
+| query_ot_quotes | exeg-S14, bs-S3 | ✓ Covered |
+| query_places | — | ✗ NOT COVERED |
+| query_events | — | ✗ NOT COVERED |
+| query_themes | — | ✗ NOT COVERED |
+| query_lexicon | — | ✗ NOT COVERED |
+| query_timeline | — | ✗ NOT COVERED |
+| query_parallel_text | — | ✗ NOT COVERED |
+| query_book_outline | — | ✗ NOT COVERED |
+| query_pericope | — | ✗ NOT COVERED |
+| query_topic | — | ✗ NOT COVERED |
+| query_doctrine | — | ✗ NOT COVERED |

--- a/tests/promptfoo/skills/argument-flow/promptfooconfig-green.yaml
+++ b/tests/promptfoo/skills/argument-flow/promptfooconfig-green.yaml
@@ -12,6 +12,9 @@
 #   S6: OT genre detection — narrative structure, not epistle logic
 #   ADV1: User pushback resistance — maintains MCP discipline
 #   S8: Clause-aware argument flow — NT proposition chain with clause-level data
+#
+# RED scenario coverage audit:
+#   S9: OT apocalyptic — Daniel 7:9-14 (genre-governed argument flow)
 
 description: "Argument Flow — GREEN phase (failure-mode corrections)"
 
@@ -224,3 +227,33 @@ tests:
           mentioned, referenced, or called in the analysis workflow.
       - type: icontains
         value: "Data Sources"
+
+  # =========================================================================
+  # Scenario 9: OT Apocalyptic — Daniel 7:9-14
+  # Correction: genre-governed argument mapping with vision-report conventions
+  # =========================================================================
+  - description: "S9 GREEN: Daniel 7:9-14 — OT apocalyptic genre-governed argument flow"
+    vars:
+      prompt: "Use the argument-flow skill for Daniel 7:9-14"
+    assert:
+      # Apocalyptic genre identified
+      - type: icontains
+        value: "apocalyptic"
+      # Genre-governed analysis
+      - type: llm-rubric
+        value: |
+          Evaluate whether the argument flow analysis of Daniel 7:9-14:
+          1. Identifies OT apocalyptic as the governing genre
+          2. Uses vision-report structural analysis (scene transitions,
+             symbolic sequences, heavenly-court conventions) rather than
+             epistolary-style connective mapping
+          3. Grounds the symbolic imagery in OT backgrounds (the four beasts
+             context of Daniel 7:1-8, heavenly court tradition, theophanic
+             fire traditions)
+          4. Maps the argument structure using genre-appropriate markers —
+             NOT standard proposition-chain connectives like "Therefore"
+             or "Because"
+
+          PASS if all four criteria are met.
+          FAIL if the vision is analyzed as narrative sequence or mapped
+          using epistolary-style connective logic.

--- a/tests/promptfoo/skills/argument-flow/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/argument-flow/promptfooconfig-red.yaml
@@ -15,6 +15,9 @@
 #
 # Phase 6 — OpenText.org clause annotations:
 #   S8: Clause annotations absent — NT proposition chain without clause-level data
+#
+# RED scenario coverage audit:
+#   S9: OT apocalyptic — Daniel 7:9-14 without genre governance
 
 description: "Argument Flow — RED phase (bare model, no skill, no MCP)"
 
@@ -210,3 +213,38 @@ tests:
 
           FAIL if the response cites structured clause-level annotation data with
           clause types, clause relations, and attribution to OpenText.org or similar.
+
+  # =========================================================================
+  # Scenario 9: OT Apocalyptic — Daniel 7:9-14 (Ancient of Days Vision)
+  # Failure: Apocalyptic symbolic imagery treated as narrative sequence;
+  # no genre governance for OT apocalyptic; no symbol-referent mapping
+  # =========================================================================
+  - description: "S9 RED: OT apocalyptic — Daniel 7:9-14 without genre governance"
+    vars:
+      prompt: "Map the argument of Daniel 7:9-14. Trace how the passage moves from the Ancient of Days scene through the 'one like a son of man' vision. What is the logical flow?"
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response exhibits ANY of these OT apocalyptic failures:
+          - Maps the passage as a narrative sequence (what happens next) rather
+            than as apocalyptic vision report with symbolic argument structure
+          - Treats the Ancient of Days, the thrones, the fire, and the son of man
+            figure as narrative events rather than symbolic elements requiring
+            genre-governed interpretation (symbol-referent mapping)
+          - Does not identify "apocalyptic" as the governing genre or does not
+            explain how apocalyptic genre constrains the argument-flow method
+          - Produces a proposition chain using epistolary-style connectives
+            (Therefore, Because, For this reason) rather than vision-report
+            structural markers (scene transition, heavenly-court sequence,
+            symbolic-act interpretation)
+          - Does not ground the symbolic imagery in its OT prophetic context
+            (the four beasts from earlier in Daniel 7, the heavenly court
+            tradition from 1 Kings 22, the theophanic fire traditions)
+
+          FAIL if the response explicitly identifies OT apocalyptic as the
+          governing genre, uses genre-appropriate structural analysis (scene
+          transitions, symbolic sequences), grounds imagery in OT backgrounds,
+          AND maps the argument using vision-report conventions rather than
+          epistolary logic.

--- a/tests/promptfoo/skills/biblical-segmentation/promptfooconfig-green.yaml
+++ b/tests/promptfoo/skills/biblical-segmentation/promptfooconfig-green.yaml
@@ -19,6 +19,9 @@
 #   SL6: Method-aware — SOAP's 5-10 verse scope for Romans 12
 #
 #   S23: Entity-aware segmentation — protagonist shifts as boundary evidence
+#
+# RED scenario coverage audit:
+#   S24: Wisdom frame-narrative — Job 1:1-5 (prologue as macro-structure unit)
 
 description: "Biblical Segmentation — GREEN phase (failure-mode corrections)"
 
@@ -281,3 +284,37 @@ tests:
           episodes without any reference to entity data.
       - type: icontains
         value: "Data Sources"
+
+  # =========================================================================
+  # Scenario 24: Wisdom Frame-Narrative — Job 1:1-5
+  # Correction: prologue as wisdom macro-structure unit, not scene segment
+  # =========================================================================
+  - description: "S24 GREEN: Job 1:1-5 — wisdom frame-narrative macro-structure"
+    vars:
+      prompt: "Use the biblical-segmentation skill. I want to study the book of Job in 8 sessions with my small group. Give me a division for the first session — how should I start with Job 1:1-5?"
+    assert:
+      # Deterministic: prologue/macro-structure awareness
+      - type: icontains-any
+        value:
+          - "prologue"
+          - "macro-structure"
+          - "frame-narrative"
+          - "wisdom"
+      # Wisdom genre awareness
+      - type: llm-rubric
+        value: |
+          Evaluate whether the segmentation response for Job:
+          1. Identifies Job as a wisdom frame-narrative (not pure narrative)
+          2. Treats the prologue (chs 1-2) as a structural unit that should
+             not be arbitrarily split at 1:5
+          3. Evaluates 1:1-5 against the book's macro-structure (prologue →
+             dialogue cycle → divine speeches → epilogue) rather than using
+             scene-boundary reasoning alone
+          4. If it suggests extending the first session beyond 1:1-5 to
+             include the full prologue setup (through at least the first
+             heavenly council scene), provides structural reasoning
+
+          PASS if the response recognizes the wisdom genre constraint and
+          evaluates the boundary against macro-structure.
+          FAIL if Job is segmented as pure narrative using scene boundaries
+          without reference to wisdom-genre structural conventions.

--- a/tests/promptfoo/skills/biblical-segmentation/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/biblical-segmentation/promptfooconfig-red.yaml
@@ -19,6 +19,9 @@
 #   SL4: Short pericope — compliance without principled minimum-size reasoning
 #   SL5: User-count deference — accepts user's suggestion without principled calculation
 #   SL6: Method-unaware slicing — produces divisions without SOAP scope constraints
+#
+# RED scenario coverage audit:
+#   S24: Wisdom frame-narrative — Job 1:1-5 segmented as pure narrative
 
 description: "Biblical Segmentation — RED phase (bare model, no skill, no MCP)"
 
@@ -304,3 +307,37 @@ tests:
 
           FAIL if the response cites structured entity data (people, places,
           events with cross-book references) as boundary evidence.
+
+  # =========================================================================
+  # Scenario 24: Wisdom Frame-Narrative — Job 1:1-5 (Prologue)
+  # Failure: Wisdom frame-narrative hybrid genre not recognized; segmented
+  # as pure narrative without wisdom-genre structural constraints
+  # =========================================================================
+  - description: "S24 RED: Wisdom frame-narrative — Job 1:1-5 segmented as pure narrative"
+    vars:
+      prompt: "I want to study the book of Job in 8 sessions with my small group. Give me a division for the first session — how should I start with Job 1:1-5?"
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response exhibits ANY of these segmentation failures:
+          - Treats Job 1:1-5 as a standalone narrative segment without
+            recognizing that Job's prologue (chs 1-2) functions as a
+            wisdom frame-narrative that must be understood as a unit
+          - Suggests stopping at 1:5 as a valid session boundary because
+            "the scene with the sons' feasting ends there" — pure
+            narrative-scene reasoning without wisdom-genre awareness
+          - Does not distinguish between narrative genre segmentation
+            (scene boundaries) and wisdom genre segmentation (the
+            prologue-dialogue-epilogue macro-structure that governs
+            the book's argument)
+          - Does not cite any structural data (paragraph breaks, discourse
+            features) to evaluate whether 1:1-5 is a valid segment
+          - Segments by verse count or chapter division rather than by
+            the book's literary architecture
+
+          FAIL if the response identifies Job as a wisdom frame-narrative,
+          treats the prologue (chs 1-2) as a structural unit, AND
+          evaluates 1:1-5 against the book's macro-structure rather than
+          using pure scene-boundary reasoning.

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-green.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-green.yaml
@@ -9,6 +9,12 @@
 #   S14: Apocalyptic genre governance (Rev 1:9-20)
 #   S15: Citation grounding via commentary_lookup (Gal 3:10-14)
 #   S16-S17: F4 self-critique (indicative ground, redemptive-historical link)
+#
+# RED scenario coverage audit:
+#   S18: Wisdom genre — Job 38:1-11 (genre-graduated method)
+#   S19: Wisdom genre — Ecclesiastes 1:1-11 (hebel semantic range)
+#   S20: Sparse MCP data — Obadiah 1-4 (degraded-data fallback)
+#   S21: Law genre — Leviticus 16:1-10 (covenantal-fulfillment framework)
 
 description: "Exegetical Notes — GREEN phase (failure-mode corrections)"
 
@@ -547,3 +553,125 @@ tests:
               ? 'All 10 sections present'
               : `Missing: [${missing.join(', ')}]`
           };
+
+  # =========================================================================
+  # Scenario 18: Wisdom Genre — Job 38:1-11
+  # Correction: genre-graduated method for wisdom theophanic poetry
+  # =========================================================================
+  - description: "S18 GREEN: Job 38:1-11 — wisdom genre governance with graduated method"
+    vars:
+      prompt: "Generate exegetical notes for Job 38:1-11 --output print"
+    assert:
+      # Genre identification present
+      - type: icontains
+        value: "wisdom"
+      # Theodicy/theophany context referenced
+      - type: llm-rubric
+        value: |
+          Evaluate whether the exegetical notes for Job 38:1-11:
+          1. Identify wisdom (or theophanic poetry) as the governing genre
+          2. Use a genre-graduated redemptive-historical method (indirect, not
+             direct promise-fulfillment arc)
+          3. Situate God's speech in the book-level theodicy argument (chs 1-2
+             setup, dialogue cycle chs 3-37, divine response chs 38-41)
+          4. Do NOT moralize the divine questions as simple humility lessons
+
+          PASS if all four criteria are met.
+          FAIL if any criterion is violated — especially if a direct
+          redemptive-historical arc is forced or the speech is moralized.
+
+  # =========================================================================
+  # Scenario 19: Wisdom Genre — Ecclesiastes 1:1-11
+  # Correction: genre-graduated method with canonical-literary framing
+  # =========================================================================
+  - description: "S19 GREEN: Ecclesiastes 1:1-11 — genre-graduated wisdom method"
+    vars:
+      prompt: "Generate exegetical notes for Ecclesiastes 1:1-11 --output print"
+    assert:
+      # hebel vocabulary addressed
+      - type: icontains
+        value: "hebel"
+      # Genre-graduated method
+      - type: llm-rubric
+        value: |
+          Evaluate whether the exegetical notes for Ecclesiastes 1:1-11:
+          1. Explore the semantic range of הֶבֶל (hebel) beyond a single flat
+             translation — discussing breath/vapor/transience/enigma options
+          2. Identify wisdom as the governing genre and explain how it constrains
+             the redemptive-historical methodology (indirect, creation-theology
+             mediated, not direct promise-fulfillment)
+          3. Place Qoheleth in canonical-literary context (the epilogue frame,
+             the wisdom tradition's role in Israel's theology)
+          4. Do NOT read Ecclesiastes as nihilistic OR as straightforwardly
+             optimistic — both are genre violations
+
+          PASS if all four criteria are met.
+          FAIL if hebel is translated flatly, a direct redemptive-historical
+          arc is forced, or canonical framing is absent.
+
+  # =========================================================================
+  # Scenario 20: Sparse MCP Data — Obadiah 1-4
+  # Correction: degraded-data fallback with explicit data-gap acknowledgment
+  # =========================================================================
+  - description: "S20 GREEN: Obadiah 1-4 — degraded-data fallback with gap acknowledgment"
+    vars:
+      prompt: "Generate exegetical notes for Obadiah 1-4 --output print"
+    assert:
+      # Deterministic: sparse data acknowledged
+      - type: icontains-any
+        value:
+          - "data gap"
+          - "sparse"
+          - "limited"
+          - "no results"
+      # Data gap acknowledgment
+      - type: llm-rubric
+        value: |
+          Evaluate whether the exegetical notes for Obadiah 1-4:
+          1. Explicitly acknowledge where MCP tool data is sparse or absent
+             (e.g., "query_places returned limited results for Edom references"
+             or "data gap: entity records sparse for this passage")
+          2. Distinguish between verified tool results and training-knowledge
+             fallbacks with different confidence labels
+          3. Do NOT fill data gaps with unacknowledged training-knowledge
+             assertions presented at the same confidence as verified data
+          4. Include whatever data IS available from MCP tools (even partial)
+
+          PASS if data sparsity is explicitly acknowledged and claims are
+          labeled by source (verified vs. training-knowledge fallback).
+          FAIL if all claims are presented at uniform confidence regardless
+          of data availability, or if sparse data is silently backfilled.
+
+  # =========================================================================
+  # Scenario 21: Law Genre — Leviticus 16:1-10
+  # Correction: covenantal-fulfillment framework with typological reading
+  # =========================================================================
+  - description: "S21 GREEN: Lev 16:1-10 — covenantal-fulfillment with typology"
+    vars:
+      prompt: "Generate exegetical notes for Leviticus 16:1-10 --output print"
+    assert:
+      # Deterministic: typological fulfillment referenced
+      - type: icontains-any
+        value:
+          - "Hebrews"
+          - "typolog"
+          - "covenantal"
+          - "fulfillment"
+      # Covenantal framework present
+      - type: llm-rubric
+        value: |
+          Evaluate whether the exegetical notes for Leviticus 16:1-10:
+          1. Identify law/ritual as the governing genre and explain how it
+             constrains interpretation (not narrative, not epistle)
+          2. Place the Day of Atonement in a covenantal-fulfillment framework —
+             specifically connecting to Hebrews 9-10 typological fulfillment
+          3. Attend to covenant administration (old covenant → new covenant
+             transition) when discussing the passage's relevance
+          4. Ground any application in indicative theology (what Christ has
+             accomplished) before imperative (how we respond)
+          5. Do NOT moralize the ritual ("we should approach God like Aaron")
+             without first grounding in the typological-fulfillment reality
+
+          PASS if all five criteria are met.
+          FAIL if the passage is treated as mere history, moralized without
+          typology, or applied directly without covenantal framework.

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
@@ -29,6 +29,7 @@
 # RED scenario coverage audit:
 #   S18: Wisdom genre — forced narrative arc on wisdom poetry (Job 38:1-11)
 #   S19: Wisdom genre — missing genre-graduated method (Ecclesiastes 1:1-11)
+#   S20: Sparse MCP data — no degraded-data fallback (Obadiah 1-4)
 
 description: "Exegetical Notes — RED phase (bare model, no skill, no MCP)"
 
@@ -535,3 +536,31 @@ tests:
           explores hebel's semantic range with nuance, uses a genre-graduated
           method for redemptive-historical placement, AND places Qoheleth in
           canonical-literary context.
+
+  # =========================================================================
+  # Scenario 20: Sparse MCP Data — Obadiah 1-4
+  # Failure: No degraded-data fallback when MCP tools return empty results;
+  # training-knowledge fills gaps without acknowledging data sparsity
+  # =========================================================================
+  - description: "S20 RED: Sparse data — Obadiah 1-4 without degraded-data fallback"
+    vars:
+      prompt: "Generate exegetical notes for Obadiah 1-4. Include entity data for Edom, cross-references to other Edom passages, and place data for the geographic references. Provide full exegetical analysis."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response exhibits ANY of these sparse-data failures:
+          - Provides entity data for Edom, geographic references, and cross-references
+            from training knowledge without acknowledging that structured data
+            may be sparse or unavailable for this passage
+          - Does not mention that MCP tools might return empty results for minor
+            prophets and does not have a degraded-data fallback strategy
+          - Presents all claims (places, people, cross-references) at uniform
+            confidence without distinguishing verified from unverified data
+          - Does not flag any data gap or indicate that Obadiah is a passage
+            where structured tool data may be limited
+
+          FAIL if the response explicitly acknowledges sparse data availability,
+          flags data gaps for specific categories, and distinguishes verified
+          tool results from training-knowledge fallbacks.

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
@@ -28,6 +28,7 @@
 #
 # RED scenario coverage audit:
 #   S18: Wisdom genre — forced narrative arc on wisdom poetry (Job 38:1-11)
+#   S19: Wisdom genre — missing genre-graduated method (Ecclesiastes 1:1-11)
 
 description: "Exegetical Notes — RED phase (bare model, no skill, no MCP)"
 
@@ -500,3 +501,37 @@ tests:
           as the governing genre, uses a genre-graduated redemptive-historical
           method (indirect, not direct), AND situates the speech in the book's
           theodicy argument structure.
+
+  # =========================================================================
+  # Scenario 19: Wisdom Genre — Ecclesiastes 1:1-11 (Vanity of Vanities)
+  # Failure: Missing genre-graduated redemptive-historical method; flat
+  # reading of hebel as "meaningless" without canonical-literary framing
+  # =========================================================================
+  - description: "S19 RED: Wisdom genre — Ecclesiastes 1:1-11 missing genre-graduated method"
+    vars:
+      prompt: "Generate exegetical notes for Ecclesiastes 1:1-11. Analyze the key Hebrew vocabulary especially הֶבֶל (hebel) and its semantic range. Include interpretive guardrails and the passage's place in the biblical storyline."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response exhibits ANY of these wisdom-genre failures:
+          - Translates הֶבֶל (hebel) flatly as "meaningless" or "vanity" without
+            exploring the semantic range (breath, vapor, enigma, transience) and
+            without noting that translation choice shapes the entire interpretation
+          - Applies a direct redemptive-historical framework rather than a
+            genre-graduated indirect approach (wisdom literature's relationship
+            to the biblical arc is mediated through creation theology, not
+            through direct promise-fulfillment)
+          - Reads Qoheleth as nihilistic or as straightforward pessimism without
+            placing it in canonical context (the epilogue's "fear God" frame,
+            the wisdom tradition's role in Israel's theology)
+          - Does not identify "wisdom" as the governing genre or does not explain
+            how wisdom genre constrains the redemptive-historical methodology
+          - Provides Hebrew vocabulary analysis from training knowledge without
+            verification caveats or MCP tool references
+
+          FAIL if the response explicitly identifies wisdom genre governance,
+          explores hebel's semantic range with nuance, uses a genre-graduated
+          method for redemptive-historical placement, AND places Qoheleth in
+          canonical-literary context.

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
@@ -25,6 +25,9 @@
 # F4 — Self-critique pass:
 #   S16: Moralistic Section 5 — imperatives without indicative ground (Col 3:1-11)
 #   S17: Missing redemptive-historical link — epistle without cross-testament arc (Eph 2:1-10)
+#
+# RED scenario coverage audit:
+#   S18: Wisdom genre — forced narrative arc on wisdom poetry (Job 38:1-11)
 
 description: "Exegetical Notes — RED phase (bare model, no skill, no MCP)"
 
@@ -464,3 +467,36 @@ tests:
           FAIL if the response explicitly marks citations as unverified training
           knowledge, calls commentary_lookup to verify positions, or adds
           verification caveats to citations that could not be confirmed.
+
+  # =========================================================================
+  # Scenario 18: Wisdom Genre — Job 38:1-11 (God's Speech from Whirlwind)
+  # Failure: Wisdom poetry treated as narrative; moralistic reading without
+  # theodicy context; forced narrative arc instead of genre-graduated method
+  # =========================================================================
+  - description: "S18 RED: Wisdom genre — Job 38:1-11 forced narrative arc on wisdom poetry"
+    vars:
+      prompt: "Generate exegetical notes for Job 38:1-11. This is God's speech from the whirlwind. Provide full exegetical analysis including lexical analysis, interpretive guardrails, and redemptive-historical significance."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response exhibits ANY of these wisdom-genre failures:
+          - Treats Job 38:1-11 as narrative (what happened next in the story)
+            rather than as wisdom-genre theophanic poetry with its own conventions
+          - Forces a direct redemptive-historical arc (Creation → Promise →
+            Fulfillment → Consummation) rather than using a genre-graduated
+            indirect approach appropriate for wisdom literature
+          - Reads God's questions as rhetorical devices for moral instruction
+            ("God is teaching Job humility") without placing them in the
+            theodicy context of the book's argument
+          - Does not identify "wisdom" or "theophanic poetry" as the governing
+            genre, or does not explain how wisdom genre constrains interpretation
+          - Ignores the book-level literary context: the suffering-innocent
+            framework (chs 1-2), the dialogue cycle (chs 3-37), and God's
+            response as resolution of the book's central question
+
+          FAIL if the response explicitly identifies wisdom/theophanic poetry
+          as the governing genre, uses a genre-graduated redemptive-historical
+          method (indirect, not direct), AND situates the speech in the book's
+          theodicy argument structure.

--- a/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/exegetical-notes/promptfooconfig-red.yaml
@@ -30,6 +30,7 @@
 #   S18: Wisdom genre — forced narrative arc on wisdom poetry (Job 38:1-11)
 #   S19: Wisdom genre — missing genre-graduated method (Ecclesiastes 1:1-11)
 #   S20: Sparse MCP data — no degraded-data fallback (Obadiah 1-4)
+#   S21: Law genre — no covenantal-fulfillment framework (Leviticus 16:1-10)
 
 description: "Exegetical Notes — RED phase (bare model, no skill, no MCP)"
 
@@ -564,3 +565,35 @@ tests:
           FAIL if the response explicitly acknowledges sparse data availability,
           flags data gaps for specific categories, and distinguishes verified
           tool results from training-knowledge fallbacks.
+
+  # =========================================================================
+  # Scenario 21: Law Genre — Leviticus 16:1-10 (Day of Atonement)
+  # Failure: OT ritual law applied flatly without covenantal-fulfillment
+  # framework; no typological connection to NT fulfillment (Hebrews 9)
+  # =========================================================================
+  - description: "S21 RED: Law genre — Lev 16:1-10 without covenantal-fulfillment framework"
+    vars:
+      prompt: "Generate exegetical notes for Leviticus 16:1-10 (the Day of Atonement instructions). Include the significance of the two goats, the role of Aaron, and the passage's theological importance. Provide full analysis with interpretive guardrails."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response exhibits ANY of these law-genre failures:
+          - Describes the ritual procedures without placing them in a
+            covenantal-fulfillment framework (the Day of Atonement's typological
+            relationship to Christ's atoning work as developed in Hebrews 9-10)
+          - Treats the passage as historical description only ("this is what
+            ancient Israel did") without connecting to progressive revelation
+          - Applies the passage directly to modern readers without attention to
+            covenant administration (old covenant → new covenant transition)
+          - Moralizes the ritual elements ("we should approach God with
+            reverence like Aaron") without grounding in indicative theology
+          - Does not identify "law/ritual" as the governing genre or does not
+            explain how law genre constrains interpretation differently from
+            narrative or epistle
+
+          FAIL if the response explicitly identifies law as the governing genre,
+          places the Day of Atonement in a covenantal-fulfillment framework
+          (typology → Hebrews 9-10), attends to covenant administration, AND
+          grounds application in indicative before imperative.

--- a/tests/promptfoo/skills/pericope-delimitation/promptfooconfig-green.yaml
+++ b/tests/promptfoo/skills/pericope-delimitation/promptfooconfig-green.yaml
@@ -10,6 +10,9 @@
 #   S7: Single verse (EXTEND) — structural boundary enforcement
 #   S10: Resistance test — data over memory (discourse features, not tradition)
 #   S11: Speaker-aware boundary — speaker changes as boundary evidence
+#
+# RED scenario coverage audit:
+#   S12: Wisdom poetry boundary — Ecclesiastes 3:1-8 (poem + prose commentary frame)
 
 description: "Pericope Delimitation — GREEN phase (failure-mode corrections)"
 
@@ -164,3 +167,36 @@ tests:
           - Entity-based evidence supplements Masoretic marker evidence
           FAIL if the response evaluates the pericope without any reference to
           structured speaker attribution data.
+
+  # =========================================================================
+  # Scenario 12: Wisdom Poetry Boundary — Ecclesiastes 3:1-8
+  # Correction: poem + prose commentary recognized as discourse unit
+  # =========================================================================
+  - description: "S12 GREEN: Ecc 3:1-8 — wisdom pericope with prose commentary frame"
+    vars:
+      prompt: "Use the pericope-delimitation skill for Ecclesiastes 3:1-8"
+    assert:
+      # Deterministic: prose commentary boundary referenced
+      - type: icontains-any
+        value:
+          - "3:9"
+          - "3:15"
+          - "3:22"
+          - "discourse unit"
+      # Boundary extension recommended
+      - type: llm-rubric
+        value: |
+          Evaluate whether the pericope assessment for Ecclesiastes 3:1-8:
+          1. Identifies the poem (3:1-8) as part of a larger discourse unit
+             that includes the prose commentary (at minimum 3:9-15)
+          2. Recommends extending the pericope to include the commentary frame
+          3. Distinguishes between poetic form boundary (3:8) and discourse
+             unit boundary (the poem + its interpretive commentary)
+          4. Cites textual evidence (discourse features, paragraph breaks, or
+             structural markers) rather than relying on thematic reasoning alone
+
+          PASS if the assessment identifies 3:1-8 as incomplete and recommends
+          extension to 3:1-15 or 3:1-22 with structural evidence.
+          FAIL if 3:1-8 is validated as a complete pericope, or if the
+          recommendation to extend is based only on thematic reasoning
+          without textual markers.

--- a/tests/promptfoo/skills/pericope-delimitation/promptfooconfig-red.yaml
+++ b/tests/promptfoo/skills/pericope-delimitation/promptfooconfig-red.yaml
@@ -12,6 +12,9 @@
 #
 # Phase 4 entity integration:
 #   S11: Speaker-unaware boundary — dialogue boundary without speaker change evidence
+#
+# RED scenario coverage audit:
+#   S12: Wisdom poetry boundary — Ecclesiastes 3:1-8 chapter divisions as boundary
 
 description: "Pericope Delimitation — RED phase (bare model, no skill, no MCP)"
 
@@ -165,3 +168,34 @@ tests:
 
           FAIL if the response uses structured speaker attribution data
           (speaker changes across v14/v16/v17) as boundary evidence.
+
+  # =========================================================================
+  # Scenario 12: Wisdom Poetry Boundary — Ecclesiastes 3:1-8
+  # Failure: Chapter divisions treated as valid pericope markers for wisdom
+  # poetry; verse-form unit (the "time for everything" poem) analyzed
+  # without considering its prose commentary frame (3:9-15)
+  # =========================================================================
+  - description: "S12 RED: Wisdom pericope — Ecc 3:1-8 chapter divisions as boundary"
+    vars:
+      prompt: "Is Ecclesiastes 3:1-8 a valid pericope for a study on 'a time for everything'? Check if the boundaries are sound."
+    assert:
+      - type: llm-rubric
+        value: |
+          CONTEXT: This is a RED-phase test evaluating a bare model WITHOUT skills or MCP tools. PASS means the expected failure mode was observed. FAIL means the bare model unexpectedly succeeded.
+
+          PASS if the response validates Ecc 3:1-8 as a complete pericope
+          without strongly objecting that the poem requires its prose
+          commentary frame (3:9-15 or 3:9-22). Signs:
+          - Treats the "time for everything" poem as a self-contained unit
+          - Accepts 3:8 as a natural conclusion because the poem ends there
+          - Does not argue that the interpretive key to the poem lies in
+            Qoheleth's reflective commentary that follows (3:9ff)
+          - Does not distinguish between the poetic form (3:1-8) and the
+            discourse unit (poem + commentary = 3:1-15 or 3:1-22)
+          - Relies on content-level reasoning ("the poem about seasons is
+            complete at v8") without citing textual boundary markers
+
+          FAIL if the response firmly insists that 3:1-8 is incomplete
+          because the prose commentary (3:9-15+) is structurally integral
+          to the discourse unit AND cites textual evidence (not just
+          thematic reasoning) for extending the pericope.


### PR DESCRIPTION
## Summary

- Created `docs/coverage-matrix.md` with full scenario inventory (65 existing + 7 new = 72 scenarios), genre×skill heatmap, and MCP tool coverage table
- Identified top 5 coverage gaps: Poetry/Wisdom (Job, Ecclesiastes), sparse-MCP-data (Obadiah), Law genre (Leviticus), OT Apocalyptic (Daniel)
- Authored 7 new RED/GREEN pairs across 4 skills:
  - **exegetical-notes:** S18 Job 38:1-11 (wisdom), S19 Ecc 1:1-11 (wisdom), S20 Obadiah 1-4 (sparse data), S21 Lev 16:1-10 (law)
  - **argument-flow:** S9 Dan 7:9-14 (OT apocalyptic)
  - **pericope-delimitation:** S12 Ecc 3:1-8 (wisdom boundary)
  - **biblical-segmentation:** S24 Job 1:1-5 (frame-narrative)
- Linked coverage matrix from CLAUDE.md

Closes #24

## Test plan

- [ ] Run RED evaluations for all 4 modified skills — new scenarios should PASS (bare model fails as expected)
- [ ] Run GREEN evaluations — new scenarios should PASS (skill corrects the failure)
- [ ] Verify coverage matrix scenario counts match actual config files
- [ ] Verify CLAUDE.md link renders correctly