### PR TITLE
feat(mcp): add confessional_lookup tool with 4 query modes

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,6 +24,7 @@ import { queryVariants, VariantsInputSchema, VariantsOutputSchema } from './tool
 import { bibleLookup, BibleLookupInputSchema, BibleLookupOutputSchema } from './tools/bible-lookup.js';
 import { commentaryLookup, CommentaryLookupInputSchema, CommentaryLookupOutputSchema } from './tools/commentary-lookup.js';
 import { parallelText, ParallelTextInputSchema, ParallelTextOutputSchema, type ParallelTextInput } from './tools/parallel-text.js';
+import { confessionalLookup, ConfessionalLookupInputSchema, ConfessionalLookupOutputSchema, type ConfessionalLookupInput } from './tools/confessional-lookup.js';
 
 // ─── Rich tool descriptions ───────────────────────────────────────────────────
 
@@ -402,6 +403,41 @@ Examples:
   - All commentaries on Romans 8:28: book="Romans", range="8:28"
   - Matthew Henry on Genesis 1:1-3: book="Genesis", range="1:1-3", commentary="matthew-henry"
   - Tyndale notes on John 3:16: book="John", range="3:16", commentary="tyndale"`;
+
+const DESC_CONFESSIONAL_LOOKUP = `Look up confessional and catechetical content from Reformed, Baptist, Lutheran, and ancient traditions.
+
+Four query modes:
+- "direct": Look up a specific document section by slug + chapter/section or question number
+- "scripture": Find which confessional statements cite a Bible passage (e.g., Romans 8:28-30)
+- "keyword": Substring search on section content (case-insensitive)
+- "list": Enumerate available documents with metadata
+
+Available documents: Westminster Confession of Faith, Westminster Shorter/Larger Catechisms, Heidelberg Catechism, Belgic Confession, Canons of Dort, London Baptist Confession 1689, Apostles' Creed, Nicene Creed, Augsburg Confession, and more.
+
+Filters (tradition: reformed|baptist|ancient|lutheran; format: confession|catechism) apply to all modes.
+
+Args:
+  - mode (string, required): "direct" | "scripture" | "keyword" | "list"
+  - document (string): Document slug — required for mode="direct". Use mode="list" to discover slugs.
+  - chapter (number, optional): Chapter number for direct mode (confession format)
+  - section (number, optional): Section number within chapter for direct mode
+  - question (number, optional): Question number for direct mode (catechism format)
+  - book (string): Bible book name — required for mode="scripture"
+  - range (string): Verse range "8:28" or "8:28-8:30" — required for mode="scripture"
+  - keyword (string): Search term — required for mode="keyword" (min 2 characters)
+  - tradition (string, optional): Filter by tradition: reformed | baptist | ancient | lutheran
+  - format (string, optional): Filter by format: confession | catechism
+  - limit (number, optional): Max sections returned (default: 50, max: 200). Does not apply to mode="list".
+
+Returns: { mode, query_info, documents: [{slug, title, year, tradition, format, sections: [{...}]}], total_documents, total_sections, truncated?, truncation_message? }
+
+Content note: Sections include both plain content and content_with_proofs (text with [1], [2] markers mapping to Scripture citations).
+
+Examples:
+  - WCF on Providence: mode="direct", document="westminster-confession-of-faith", chapter=5
+  - Romans 8:28 citations: mode="scripture", book="Romans", range="8:28"
+  - Reformed confessions on election: mode="keyword", keyword="election", tradition="reformed"
+  - All Reformed catechisms: mode="list", tradition="reformed", format="catechism"`;
 
 const DESC_PARALLEL_TEXT = `Compare biblical text across multiple translations side by side.
 
@@ -852,6 +888,23 @@ function createServer(): McpServer {
       () => parallelText(normalizedArgs as unknown as ParallelTextInput)
     );
   });
+
+  server.registerTool('confessional_lookup', {
+    title: 'Confessional Lookup',
+    description: DESC_CONFESSIONAL_LOOKUP,
+    inputSchema: ConfessionalLookupInputSchema,
+    outputSchema: ConfessionalLookupOutputSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, async (args, _extra) =>
+    cachedToolCall('confessional_lookup', args as unknown as Record<string, unknown>, () =>
+      confessionalLookup(args as unknown as ConfessionalLookupInput)
+    )
+  );
 
   return server;
 }

--- a/server/src/tools/confessional-lookup.test.ts
+++ b/server/src/tools/confessional-lookup.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { confessionalLookup } from './confessional-lookup.js';
+
+// Mock the database query module
+vi.mock('../db/query.js', () => ({
+  query: vi.fn(),
+}));
+
+// Mock the books module
+vi.mock('../db/books.js', () => ({
+  lookupBook: vi.fn(),
+  suggestBooks: vi.fn(),
+}));
+
+import { query } from '../db/query.js';
+import { lookupBook, suggestBooks } from '../db/books.js';
+
+const mockQuery = vi.mocked(query);
+const mockLookupBook = vi.mocked(lookupBook);
+const mockSuggestBooks = vi.mocked(suggestBooks);
+
+// Minimal section row used in multiple tests
+const sectionRow = {
+  slug: 'wcf',
+  title: 'Westminster Confession of Faith',
+  year: 1647,
+  tradition: 'reformed',
+  format: 'confession',
+  section_id: 1,
+  chapter_number: 5,
+  chapter_title: 'Of Providence',
+  section_number: 1,
+  content: 'God the great Creator...',
+  content_with_proofs: 'God the great Creator... [1]',
+  question_number: null,
+  question: null,
+  answer: null,
+  answer_with_proofs: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSuggestBooks.mockReturnValue([]);
+});
+
+// ─── mode="list" ──────────────────────────────────────────────────────────────
+
+describe('mode="list"', () => {
+  it('returns all documents with empty sections arrays when no filters applied', async () => {
+    mockQuery.mockResolvedValue([
+      { slug: 'wcf', title: 'Westminster Confession of Faith', year: 1647, tradition: 'reformed', format: 'confession', authors: null, source: 'Creeds.json', id: 1 },
+      { slug: 'hc', title: 'Heidelberg Catechism', year: 1563, tradition: 'reformed', format: 'catechism', authors: null, source: 'Creeds.json', id: 2 },
+    ]);
+
+    const result = await confessionalLookup({ mode: 'list' });
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.mode).toBe('list');
+    expect(body.total_documents).toBe(2);
+    expect(body.documents[0].sections).toEqual([]);
+    expect(body.documents[1].sections).toEqual([]);
+  });
+
+  it('passes tradition filter to SQL', async () => {
+    mockQuery.mockResolvedValue([]);
+
+    await confessionalLookup({ mode: 'list', tradition: 'reformed' });
+
+    const sqlArg = mockQuery.mock.calls[0][0] as string;
+    expect(sqlArg).toContain('tradition = ?');
+    const paramsArg = mockQuery.mock.calls[0][1] as unknown[];
+    expect(paramsArg).toContain('reformed');
+  });
+});
+
+// ─── mode="direct" ────────────────────────────────────────────────────────────
+
+describe('mode="direct"', () => {
+  it('returns MISSING_DOCUMENT error when document slug omitted', async () => {
+    const result = await confessionalLookup({ mode: 'direct' });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error.code).toBe('MISSING_DOCUMENT');
+  });
+
+  it('returns DOCUMENT_NOT_FOUND when slug is unknown', async () => {
+    mockQuery.mockResolvedValue([]); // empty doc query result
+
+    const result = await confessionalLookup({ mode: 'direct', document: 'nonexistent-doc' });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error.code).toBe('DOCUMENT_NOT_FOUND');
+  });
+
+  it('fetches all sections for document when no chapter/question specified', async () => {
+    // First query: document lookup; Second query: sections
+    mockQuery
+      .mockResolvedValueOnce([{ id: 1, slug: 'wcf', title: 'Westminster Confession of Faith', year: 1647, tradition: 'reformed', format: 'confession' }])
+      .mockResolvedValueOnce([sectionRow]);
+
+    const result = await confessionalLookup({ mode: 'direct', document: 'wcf' });
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.documents[0].sections).toHaveLength(1);
+    expect(body.documents[0].sections[0].chapter_number).toBe(5);
+  });
+
+  it('adds chapter_number clause when chapter is specified', async () => {
+    mockQuery
+      .mockResolvedValueOnce([{ id: 1, slug: 'wcf', title: 'WCF', year: 1647, tradition: 'reformed', format: 'confession' }])
+      .mockResolvedValueOnce([sectionRow]);
+
+    await confessionalLookup({ mode: 'direct', document: 'wcf', chapter: 5 });
+
+    const secSql = mockQuery.mock.calls[1][0] as string;
+    expect(secSql).toContain('chapter_number = ?');
+    const secParams = mockQuery.mock.calls[1][1] as unknown[];
+    expect(secParams).toContain(5);
+  });
+
+  it('adds question_number clause when question is specified', async () => {
+    const catRow = { ...sectionRow, chapter_number: null, section_number: null, question_number: 1, question: 'What is your only comfort?', answer: 'That I...', answer_with_proofs: 'That I... [1]', content: null, content_with_proofs: null };
+    mockQuery
+      .mockResolvedValueOnce([{ id: 2, slug: 'hc', title: 'Heidelberg Catechism', year: 1563, tradition: 'reformed', format: 'catechism' }])
+      .mockResolvedValueOnce([catRow]);
+
+    await confessionalLookup({ mode: 'direct', document: 'hc', question: 1 });
+
+    const secSql = mockQuery.mock.calls[1][0] as string;
+    expect(secSql).toContain('question_number = ?');
+    const secParams = mockQuery.mock.calls[1][1] as unknown[];
+    expect(secParams).toContain(1);
+  });
+});
+
+// ─── mode="scripture" ─────────────────────────────────────────────────────────
+
+describe('mode="scripture"', () => {
+  it('returns MISSING_BOOK error when book omitted', async () => {
+    const result = await confessionalLookup({ mode: 'scripture', range: '8:28' });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error.code).toBe('MISSING_BOOK');
+  });
+
+  it('returns MISSING_RANGE error when range omitted', async () => {
+    const result = await confessionalLookup({ mode: 'scripture', book: 'Romans' });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error.code).toBe('MISSING_RANGE');
+  });
+
+  it('returns BOOK_NOT_FOUND with suggestions for unknown book', async () => {
+    mockLookupBook.mockReturnValue(null);
+    mockSuggestBooks.mockReturnValue(['romans', 'revelation']);
+
+    const result = await confessionalLookup({ mode: 'scripture', book: 'Roamns', range: '8:28' });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error.code).toBe('BOOK_NOT_FOUND');
+    expect(body.error.suggestions).toEqual(['romans', 'revelation']);
+  });
+
+  it('returns INVALID_RANGE for malformed range', async () => {
+    mockLookupBook.mockReturnValue({ canonical: 'romans', displayName: 'Romans', testament: 'nt', morphologyFile: 'romans' });
+
+    const result = await confessionalLookup({ mode: 'scripture', book: 'Romans', range: 'notarange' });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error.code).toBe('INVALID_RANGE');
+  });
+
+  it('builds range boundary SQL and returns document-grouped result', async () => {
+    mockLookupBook.mockReturnValue({ canonical: 'romans', displayName: 'Romans', testament: 'nt', morphologyFile: 'romans' });
+    mockQuery.mockResolvedValue([sectionRow]);
+
+    const result = await confessionalLookup({ mode: 'scripture', book: 'Romans', range: '8:28' });
+
+    expect(result.isError).toBeFalsy();
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('confessional_proof_texts');
+    expect(sql).toContain('JOIN confessional_sections');
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.mode).toBe('scripture');
+    expect(body.documents).toHaveLength(1);
+    expect(body.documents[0].slug).toBe('wcf');
+  });
+});
+
+// ─── mode="keyword" ───────────────────────────────────────────────────────────
+
+describe('mode="keyword"', () => {
+  it('returns MISSING_KEYWORD error when keyword omitted', async () => {
+    const result = await confessionalLookup({ mode: 'keyword' });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error.code).toBe('MISSING_KEYWORD');
+  });
+
+  it('returns KEYWORD_TOO_SHORT error for single-character keyword', async () => {
+    const result = await confessionalLookup({ mode: 'keyword', keyword: 'a' });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.error.code).toBe('KEYWORD_TOO_SHORT');
+  });
+
+  it('wraps keyword in % wildcards for LIKE query', async () => {
+    mockQuery.mockResolvedValue([sectionRow]);
+
+    await confessionalLookup({ mode: 'keyword', keyword: 'election' });
+
+    const params = mockQuery.mock.calls[0][1] as unknown[];
+    expect(params[0]).toBe('%election%');
+    expect(params[1]).toBe('%election%');
+    expect(params[2]).toBe('%election%');
+  });
+
+  it('passes tradition filter when provided', async () => {
+    mockQuery.mockResolvedValue([sectionRow]);
+
+    await confessionalLookup({ mode: 'keyword', keyword: 'election', tradition: 'reformed' });
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('cd.tradition = ?');
+    const params = mockQuery.mock.calls[0][1] as unknown[];
+    expect(params).toContain('reformed');
+  });
+
+  it('returns document-grouped result', async () => {
+    mockQuery.mockResolvedValue([sectionRow]);
+
+    const result = await confessionalLookup({ mode: 'keyword', keyword: 'election' });
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(body.total_documents).toBe(1);
+    expect(body.total_sections).toBe(1);
+  });
+});
+
+// ─── character-limit guard ────────────────────────────────────────────────────
+
+describe('character-limit guard', () => {
+  it('truncates by removing documents with fewest sections when limit exceeded', async () => {
+    // Generate 60 rows with unique slugs — each becomes its own document (1 section each)
+    // 60 docs × ~300 chars each = ~18k — may or may not exceed 25k depending on content size
+    // Use longer content to ensure we exceed the limit
+    const largeContent = 'A'.repeat(500);
+    const rows = Array.from({ length: 60 }, (_, i) => ({
+      ...sectionRow,
+      slug: `doc-${i}`,
+      title: `Document ${i} with a fairly long title to increase payload size`,
+      section_id: i + 1,
+      content: largeContent,
+      content_with_proofs: largeContent + ' [1]',
+    }));
+    mockQuery.mockResolvedValue(rows);
+
+    const result = await confessionalLookup({ mode: 'keyword', keyword: 'election' });
+
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    // The serialized result should be within the character limit (with margin for truncation_message)
+    expect(JSON.stringify(body).length).toBeLessThanOrEqual(25_000 + 600);
+    // If truncation occurred, truncated flag should be set
+    if (body.truncated) {
+      expect(body.truncation_message).toBeTruthy();
+      expect(body.documents.length).toBeLessThan(60);
+    }
+  });
+});

--- a/server/src/tools/confessional-lookup.ts
+++ b/server/src/tools/confessional-lookup.ts
@@ -1,0 +1,440 @@
+import { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { query } from '../db/query.js';
+import { lookupBook, suggestBooks } from '../db/books.js';
+import { parseVerseRange } from './utils.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CHARACTER_LIMIT = 25_000;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const MIN_KEYWORD_LENGTH = 2;
+
+// ─── Input Schema ─────────────────────────────────────────────────────────────
+
+export const ConfessionalLookupInputSchema = {
+  mode: z.enum(['direct', 'scripture', 'keyword', 'list'])
+    .describe(
+      'Query mode:\n' +
+      '  "direct" — lookup by document slug + chapter/section or question number\n' +
+      '  "scripture" — which confessional statements cite a Bible passage (book + range required)\n' +
+      '  "keyword" — substring search on section content (keyword required)\n' +
+      '  "list" — enumerate available documents with metadata'
+    ),
+  document: z.string().optional()
+    .describe('Document slug (e.g., "westminster-confession-of-faith"). Required for mode="direct".'),
+  chapter: z.number().optional()
+    .describe('Chapter number. For confession sections in mode="direct".'),
+  section: z.number().optional()
+    .describe('Section number within chapter. For confession sections in mode="direct".'),
+  question: z.number().optional()
+    .describe('Question number. For catechism Q&A in mode="direct".'),
+  book: z.string().optional()
+    .describe('Bible book name in any common form (e.g., "Romans", "Gen"). Required for mode="scripture".'),
+  range: z.string().optional()
+    .describe('Verse range: "8:28-8:30", "8:28-30", or single verse "8:28". Required for mode="scripture".'),
+  keyword: z.string().optional()
+    .describe('Substring to search in section content. Required for mode="keyword". Case-insensitive LIKE match.'),
+  tradition: z.enum(['reformed', 'baptist', 'ancient', 'lutheran']).optional()
+    .describe('Filter by confessional tradition.'),
+  format: z.enum(['confession', 'catechism']).optional()
+    .describe('Filter by document format.'),
+  limit: z.number().optional()
+    .describe('Maximum sections returned per mode (default: 50, max: 200). Applies to scripture, keyword, and direct without a specific section/question.'),
+};
+
+export type ConfessionalLookupInput = z.output<z.ZodObject<typeof ConfessionalLookupInputSchema>>;
+
+// ─── Output Schema ────────────────────────────────────────────────────────────
+
+export const ConfessionalLookupOutputSchema = {
+  mode: z.string(),
+  query_info: z.object({
+    document: z.string().optional(),
+    book: z.string().optional(),
+    range: z.string().optional(),
+    keyword: z.string().optional(),
+    tradition: z.string().optional(),
+    format: z.string().optional(),
+  }),
+  documents: z.array(z.object({
+    slug: z.string(),
+    title: z.string(),
+    year: z.number().nullable(),
+    tradition: z.string(),
+    format: z.string(),
+    sections: z.array(z.object({
+      chapter_number: z.number().nullable(),
+      chapter_title: z.string().nullable(),
+      section_number: z.number().nullable(),
+      content: z.string().nullable(),
+      content_with_proofs: z.string().nullable(),
+      question_number: z.number().nullable(),
+      question: z.string().nullable(),
+      answer: z.string().nullable(),
+      answer_with_proofs: z.string().nullable(),
+    })),
+  })),
+  total_documents: z.number(),
+  total_sections: z.number(),
+  truncated: z.boolean().optional(),
+  truncation_message: z.string().optional(),
+};
+
+// ─── Helper: build error response ────────────────────────────────────────────
+
+function errorResponse(code: string, message: string, suggestions?: string[]): CallToolResult {
+  const body: Record<string, unknown> = { error: { code, message } };
+  if (suggestions) body.error = { ...body.error as object, suggestions };
+  return { content: [{ type: 'text', text: JSON.stringify(body) }], isError: true };
+}
+
+// ─── Helper: apply character-limit guard ─────────────────────────────────────
+
+function applyCharacterLimit(
+  result: Record<string, unknown>,
+  documents: Array<{ slug: string; sections: unknown[] }>,
+): Record<string, unknown> {
+  const serialized = JSON.stringify(result);
+  if (serialized.length <= CHARACTER_LIMIT || documents.length <= 1) return result;
+
+  const sorted = [...documents].sort((a, b) => a.sections.length - b.sections.length);
+  let truncated = sorted;
+  while (
+    JSON.stringify({ ...result, documents: truncated }).length > CHARACTER_LIMIT &&
+    truncated.length > 1
+  ) {
+    truncated = truncated.slice(1);
+  }
+  return {
+    ...result,
+    documents: truncated,
+    truncated: true,
+    truncation_message: `Response truncated from ${documents.length} to ${truncated.length} documents (character limit). Use tradition/format filters or the limit parameter to narrow results.`,
+  };
+}
+
+// ─── Helper: group flat SQL rows into document-grouped structure ──────────────
+
+type DocRow = Record<string, unknown>;
+
+function groupRowsByDocument(rows: DocRow[]): Array<{
+  slug: string; title: string; year: number | null;
+  tradition: string; format: string;
+  sections: Array<{
+    chapter_number: number | null; chapter_title: string | null;
+    section_number: number | null; content: string | null;
+    content_with_proofs: string | null; question_number: number | null;
+    question: string | null; answer: string | null; answer_with_proofs: string | null;
+  }>;
+}> {
+  const docMap = new Map<string, ReturnType<typeof groupRowsByDocument>[number]>();
+  const sectionSeen = new Map<string, Set<number>>();
+
+  for (const row of rows) {
+    const slug = row.slug as string;
+    if (!docMap.has(slug)) {
+      docMap.set(slug, {
+        slug,
+        title: row.title as string,
+        year: row.year as number | null,
+        tradition: row.tradition as string,
+        format: row.format as string,
+        sections: [],
+      });
+      sectionSeen.set(slug, new Set());
+    }
+    const sectionId = row.section_id as number;
+    if (!sectionSeen.get(slug)!.has(sectionId)) {
+      sectionSeen.get(slug)!.add(sectionId);
+      docMap.get(slug)!.sections.push({
+        chapter_number: row.chapter_number as number | null,
+        chapter_title: row.chapter_title as string | null,
+        section_number: row.section_number as number | null,
+        content: row.content as string | null,
+        content_with_proofs: row.content_with_proofs as string | null,
+        question_number: row.question_number as number | null,
+        question: row.question as string | null,
+        answer: row.answer as string | null,
+        answer_with_proofs: row.answer_with_proofs as string | null,
+      });
+    }
+  }
+  return [...docMap.values()];
+}
+
+// ─── Mode: list ───────────────────────────────────────────────────────────────
+
+async function handleList(args: ConfessionalLookupInput): Promise<CallToolResult> {
+  let sql = `SELECT id, slug, title, year, tradition, format, authors, source
+             FROM confessional_documents`;
+  const params: unknown[] = [];
+  const conditions: string[] = [];
+
+  if (args.tradition) {
+    conditions.push('tradition = ?');
+    params.push(args.tradition);
+  }
+  if (args.format) {
+    conditions.push('format = ?');
+    params.push(args.format);
+  }
+  if (conditions.length > 0) {
+    sql += ' WHERE ' + conditions.join(' AND ');
+  }
+  sql += ' ORDER BY tradition, year, slug';
+
+  const rows = await query(sql, params);
+  const documents = rows.map(row => ({
+    slug: row.slug as string,
+    title: row.title as string,
+    year: row.year as number | null,
+    tradition: row.tradition as string,
+    format: row.format as string,
+    sections: [] as never[],
+  }));
+
+  const result: Record<string, unknown> = {
+    mode: 'list',
+    query_info: {
+      ...(args.tradition ? { tradition: args.tradition } : {}),
+      ...(args.format ? { format: args.format } : {}),
+    },
+    documents,
+    total_documents: documents.length,
+    total_sections: 0,
+  };
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(result) }],
+    structuredContent: result,
+  };
+}
+
+// ─── Mode: direct ─────────────────────────────────────────────────────────────
+
+async function handleDirect(args: ConfessionalLookupInput): Promise<CallToolResult> {
+  if (!args.document) {
+    return errorResponse('MISSING_DOCUMENT', 'document slug is required for mode="direct". Use mode="list" to discover available slugs.');
+  }
+
+  // Fetch document by slug
+  let docSql = `SELECT id, slug, title, year, tradition, format
+                FROM confessional_documents WHERE slug = ?`;
+  const docParams: unknown[] = [args.document];
+
+  if (args.tradition) { docSql += ' AND tradition = ?'; docParams.push(args.tradition); }
+  if (args.format)    { docSql += ' AND format = ?';    docParams.push(args.format); }
+
+  const docRows = await query(docSql, docParams);
+  if (docRows.length === 0) {
+    return errorResponse('DOCUMENT_NOT_FOUND', `Document slug "${args.document}" not found. Use mode="list" to discover available documents.`);
+  }
+  const doc = docRows[0];
+
+  // Fetch sections
+  let secSql = `
+    SELECT id as section_id, chapter_number, chapter_title, section_number,
+           content, content_with_proofs,
+           question_number, question, answer, answer_with_proofs
+    FROM confessional_sections
+    WHERE document_id = ?
+  `;
+  const secParams: unknown[] = [doc.id];
+
+  if (args.question !== undefined) {
+    secSql += ' AND question_number = ?';
+    secParams.push(args.question);
+  } else if (args.chapter !== undefined) {
+    secSql += ' AND chapter_number = ?';
+    secParams.push(args.chapter);
+    if (args.section !== undefined) {
+      secSql += ' AND section_number = ?';
+      secParams.push(args.section);
+    }
+  }
+  secSql += ' ORDER BY chapter_number, section_number, question_number LIMIT ?';
+  const lim = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  secParams.push(lim);
+
+  const secRows = await query(secSql, secParams);
+  const sections = secRows.map(r => ({
+    chapter_number: r.chapter_number as number | null,
+    chapter_title: r.chapter_title as string | null,
+    section_number: r.section_number as number | null,
+    content: r.content as string | null,
+    content_with_proofs: r.content_with_proofs as string | null,
+    question_number: r.question_number as number | null,
+    question: r.question as string | null,
+    answer: r.answer as string | null,
+    answer_with_proofs: r.answer_with_proofs as string | null,
+  }));
+
+  const documents = [{
+    slug: doc.slug as string,
+    title: doc.title as string,
+    year: doc.year as number | null,
+    tradition: doc.tradition as string,
+    format: doc.format as string,
+    sections,
+  }];
+
+  const result: Record<string, unknown> = {
+    mode: 'direct',
+    query_info: {
+      document: args.document,
+      ...(args.tradition ? { tradition: args.tradition } : {}),
+      ...(args.format ? { format: args.format } : {}),
+    },
+    documents,
+    total_documents: 1,
+    total_sections: sections.length,
+  };
+
+  const finalResult = applyCharacterLimit(result, documents);
+  return {
+    content: [{ type: 'text', text: JSON.stringify(finalResult) }],
+    structuredContent: finalResult,
+  };
+}
+
+// ─── Mode: scripture ──────────────────────────────────────────────────────────
+
+async function handleScripture(args: ConfessionalLookupInput): Promise<CallToolResult> {
+  if (!args.book) {
+    return errorResponse('MISSING_BOOK', 'book is required for mode="scripture".');
+  }
+  if (!args.range) {
+    return errorResponse('MISSING_RANGE', 'range is required for mode="scripture".');
+  }
+
+  const bookInfo = lookupBook(args.book);
+  if (!bookInfo) {
+    return errorResponse('BOOK_NOT_FOUND', `Book "${args.book}" not found.`, suggestBooks(args.book));
+  }
+
+  const verseRange = parseVerseRange(args.range);
+  if ('error' in verseRange) {
+    return errorResponse('INVALID_RANGE', verseRange.error);
+  }
+
+  const lim = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const conditions: string[] = [
+    'cpt.book = ?',
+    '(cpt.chapter > ? OR (cpt.chapter = ? AND cpt.verse >= ?))',
+    '(cpt.chapter < ? OR (cpt.chapter = ? AND cpt.verse <= ?))',
+  ];
+  const params: unknown[] = [
+    bookInfo.canonical,
+    verseRange.startChapter, verseRange.startChapter, verseRange.startVerse,
+    verseRange.endChapter, verseRange.endChapter, verseRange.endVerse,
+  ];
+
+  if (args.tradition) { conditions.push('cd.tradition = ?'); params.push(args.tradition); }
+  if (args.format)    { conditions.push('cd.format = ?');    params.push(args.format); }
+
+  const sql = `
+    SELECT DISTINCT
+      cd.slug, cd.title, cd.year, cd.tradition, cd.format,
+      cs.id as section_id, cs.chapter_number, cs.chapter_title, cs.section_number,
+      cs.content, cs.content_with_proofs,
+      cs.question_number, cs.question, cs.answer, cs.answer_with_proofs
+    FROM confessional_proof_texts cpt
+    JOIN confessional_sections cs ON cs.id = cpt.section_id
+    JOIN confessional_documents cd ON cd.id = cs.document_id
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY cd.tradition, cd.slug, cs.chapter_number, cs.section_number, cs.question_number
+    LIMIT ?
+  `;
+  params.push(lim);
+
+  const rows = await query(sql, params);
+  const documents = groupRowsByDocument(rows);
+
+  const result: Record<string, unknown> = {
+    mode: 'scripture',
+    query_info: {
+      book: bookInfo.displayName,
+      range: args.range,
+      ...(args.tradition ? { tradition: args.tradition } : {}),
+      ...(args.format ? { format: args.format } : {}),
+    },
+    documents,
+    total_documents: documents.length,
+    total_sections: documents.reduce((s, d) => s + d.sections.length, 0),
+  };
+
+  const finalResult = applyCharacterLimit(result, documents);
+  return {
+    content: [{ type: 'text', text: JSON.stringify(finalResult) }],
+    structuredContent: finalResult,
+  };
+}
+
+// ─── Mode: keyword ────────────────────────────────────────────────────────────
+
+async function handleKeyword(args: ConfessionalLookupInput): Promise<CallToolResult> {
+  if (!args.keyword) {
+    return errorResponse('MISSING_KEYWORD', 'keyword is required for mode="keyword".');
+  }
+  if (args.keyword.length < MIN_KEYWORD_LENGTH) {
+    return errorResponse('KEYWORD_TOO_SHORT', `Keyword must be at least ${MIN_KEYWORD_LENGTH} characters.`);
+  }
+
+  const pattern = `%${args.keyword}%`;
+  const lim = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const conditions: string[] = [
+    '(cs.content LIKE ? OR cs.answer LIKE ? OR cs.question LIKE ?)',
+  ];
+  const params: unknown[] = [pattern, pattern, pattern];
+
+  if (args.tradition) { conditions.push('cd.tradition = ?'); params.push(args.tradition); }
+  if (args.format)    { conditions.push('cd.format = ?');    params.push(args.format); }
+
+  const sql = `
+    SELECT
+      cd.slug, cd.title, cd.year, cd.tradition, cd.format,
+      cs.id as section_id, cs.chapter_number, cs.chapter_title, cs.section_number,
+      cs.content, cs.content_with_proofs,
+      cs.question_number, cs.question, cs.answer, cs.answer_with_proofs
+    FROM confessional_sections cs
+    JOIN confessional_documents cd ON cd.id = cs.document_id
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY cd.tradition, cd.slug, cs.chapter_number, cs.section_number, cs.question_number
+    LIMIT ?
+  `;
+  params.push(lim);
+
+  const rows = await query(sql, params);
+  const documents = groupRowsByDocument(rows);
+
+  const result: Record<string, unknown> = {
+    mode: 'keyword',
+    query_info: {
+      keyword: args.keyword,
+      ...(args.tradition ? { tradition: args.tradition } : {}),
+      ...(args.format ? { format: args.format } : {}),
+    },
+    documents,
+    total_documents: documents.length,
+    total_sections: documents.reduce((s, d) => s + d.sections.length, 0),
+  };
+
+  const finalResult = applyCharacterLimit(result, documents);
+  return {
+    content: [{ type: 'text', text: JSON.stringify(finalResult) }],
+    structuredContent: finalResult,
+  };
+}
+
+// ─── Main Handler ─────────────────────────────────────────────────────────────
+
+export async function confessionalLookup(args: ConfessionalLookupInput): Promise<CallToolResult> {
+  switch (args.mode) {
+    case 'direct':    return handleDirect(args);
+    case 'scripture': return handleScripture(args);
+    case 'keyword':   return handleKeyword(args);
+    case 'list':      return handleList(args);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `confessional_lookup` MCP tool to `server/src/tools/confessional-lookup.ts` with four query modes: `direct`, `scripture`, `keyword`, and `list`
- Registers the tool in `server/src/index.ts` following the existing `commentary_lookup` pattern
- Includes 17 Vitest unit tests covering all 4 modes, 8 validation error paths, and the character-limit truncation guard

Closes #38

## Implementation Details

The tool mirrors `commentary-lookup.ts` architecture:
- Zod input/output schemas exported for registration in `index.ts`
- `cachedToolCall()` wrapper for Cloudflare Worker response caching
- `lookupBook()`/`suggestBooks()` for scripture-mode book normalization
- `parseVerseRange()` for verse range parsing
- Progressive document-level truncation guard at 25,000 characters

**Note:** This branch includes F1's migration `0013_add_confessional.sql` and ETL scripts (merged from `feat/F1-confessional-schema-etl`). When merging, if F1 (#45) is merged first, this branch should be rebased to drop the F1 commits.

## Test plan

- [ ] All 63 tests pass (`npm test` in `server/`)
- [ ] TypeScript compiles with zero errors (`npm run typecheck` in `server/`)
- [ ] Verify F1 migration #45 is merged before deploying this tool to production D1
- [ ] F4 deploy: update `AVAILABLE_TOOLS` in `list-books.ts` to include `confessional_lookup`