### PR TITLE
feat(mcp): deploy confessional_lookup and bump server version to 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The MCP server provides linguistic data via Cloudflare Workers + D1 (edge SQLite
 | `query_themes_for_lemmas` | Resolve morphology lemmas to vocabulary theme names | Both testaments |
 | `query_lemmas` | Cross-book lemma distribution | Both testaments |
 | `query_theme` | Cross-book distribution of a thematic keyword group | Both testaments |
+| `confessional_lookup` | Confessional and catechetical documents from Reformed, Baptist, Lutheran, and ancient traditions — lookup by slug, scripture citation, keyword, or list | Non-biblical |
 
 Skills call these automatically. You can invoke them directly if needed.
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -512,7 +512,7 @@ async function cachedToolCall(
 // per request is cheap (constructor only sets up handler maps, no I/O).
 function createServer(): McpServer {
   const server = new McpServer(
-    { name: 'claude-of-alexandria-mcp', version: '3.0.0' },
+    { name: 'claude-of-alexandria-mcp', version: '4.0.0' },
     { capabilities: { tools: {} } }
   );
 
@@ -933,12 +933,12 @@ export default {
       try {
         await env.DB.prepare('SELECT 1').first();
         return new Response(
-          JSON.stringify({ status: 'ok', version: '3.0.0', db: 'connected' }),
+          JSON.stringify({ status: 'ok', version: '4.0.0', db: 'connected' }),
           { headers: { 'Content-Type': 'application/json', ...CORS_HEADERS } }
         );
       } catch {
         return new Response(
-          JSON.stringify({ status: 'degraded', version: '3.0.0', db: 'unreachable' }),
+          JSON.stringify({ status: 'degraded', version: '4.0.0', db: 'unreachable' }),
           { status: 503, headers: { 'Content-Type': 'application/json', ...CORS_HEADERS } }
         );
       }

--- a/server/src/tools/list-books.ts
+++ b/server/src/tools/list-books.ts
@@ -56,6 +56,7 @@ const AVAILABLE_TOOLS = [
   'bible_lookup - look up verse text in 6 translations (OT + NT)',
   'commentary_lookup - look up commentary entries from 6 commentaries (OT + NT)',
   'parallel_text - compare verse text across multiple translations (OT + NT)',
+  'confessional_lookup - confessional and catechetical lookup with 4 modes: direct (by document slug + chapter/section or question), scripture (find statements citing a Bible passage), keyword (substring search on section content), list (enumerate available documents). Traditions: reformed, baptist, ancient, lutheran.',
 ] as const;
 
 const AVAILABLE_TRANSLATIONS = [


### PR DESCRIPTION
## Summary

- Merges F1 (D1 migration 0013 + ETL) and F2 (confessional_lookup MCP tool) into this branch
- Bumps MCP server version from `3.0.0` to `4.0.0` in `createServer()` and both health endpoint response bodies (`index.ts`)
- Adds `confessional_lookup` to the `AVAILABLE_TOOLS` discovery array in `list-books.ts`
- Adds `confessional_lookup` row to the tool table in `README.md`

Closes the code side of #39. Manual deployment steps (Tasks 1–4: apply migration 0013, seed confessional data, run `wrangler deploy`, verify all 4 query modes) must be completed by the user before issue #39 can be closed.

## Files Changed

- `server/src/index.ts` — version `3.0.0` → `4.0.0` (createServer + health endpoints)
- `server/src/tools/list-books.ts` — `confessional_lookup` added to `AVAILABLE_TOOLS`
- `README.md` — `confessional_lookup` row added to tool table

## Test plan

- [ ] `npm run typecheck` passes (verified during build)
- [ ] Manual: apply migration 0013 to production D1 (`wrangler d1 migrations apply`)
- [ ] Manual: seed confessional data (`npx tsx scripts/seed-confessional.ts`)
- [ ] Manual: `wrangler deploy` and verify `GET /health` returns `"version": "4.0.0"`
- [ ] Manual: smoke-test all 4 query modes (`list`, `direct`, `scripture`, `keyword`) via MCP client